### PR TITLE
Navigation 이슈 수정하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/AccountActivity.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountActivity.kt
@@ -40,7 +40,6 @@ fun AccountApp() {
     val currentScreen =
         allScreens.find { currentDestination?.route?.startsWith(it.route) ?: false } ?: History
 
-    println(currentDestination?.route)
     AccountBookTheme() {
         Scaffold(
             bottomBar = {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.seom.accountbook.R
-import com.seom.accountbook.mock.histories
-import com.seom.accountbook.model.BaseCount
 import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
 import com.seom.accountbook.model.history.HistoryType

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -37,28 +37,17 @@ fun HistoryScreen(
     viewModel: HistoryViewModel,
     onPushNavigate: (String, String) -> Unit
 ) {
-    var histories by remember { mutableStateOf<List<HistoryModel>>(emptyList()) }
-    val selectedItem = remember { viewModel.selectedItem }
 
-    val observer = viewModel.historyUiState.collectAsState()
-    when (val result = observer.value) {
-        HistoryUiState.Loading -> {}
-        is HistoryUiState.Error -> {}
-        is HistoryUiState.Success.SuccessFetch -> {
-            histories = result.histories
-        }
-        is HistoryUiState.Success.SuccessRemove -> {
-            histories = histories.filter { (it.id in selectedItem).not() }
-            selectedItem.clear()
-        }
-        HistoryUiState.UnInitialized -> {
-            val current = LocalDate.now()
+    LaunchedEffect(key1 = Unit) {
+        val current = LocalDate.now()
 
-            val year = current.year
-            val month = current.month.value
-            viewModel.fetchData(year, month)
-        }
+        val year = current.year
+        val month = current.month.value
+        viewModel.fetchData(year, month)
     }
+
+    val selectedItem = remember { viewModel.selectedItem }
+    var histories = viewModel.histories.collectAsState()
 
     DateAppBar(
         onDateChange = { date ->
@@ -66,7 +55,7 @@ fun HistoryScreen(
             viewModel.fetchData(date.year, date.month.value)
         }, children = {
             HistoryBody(
-                histories = histories,
+                histories = histories.value,
                 selectedItem = selectedItem,
                 onClickItem = {
                     if (selectedItem.isEmpty()) {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/post/PostViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/post/PostViewModel.kt
@@ -75,6 +75,11 @@ class PostViewModel(
         _content.value = newContent
     }
 
+    private val _methods = MutableStateFlow<List<MethodEntity>>(emptyList())
+    var methods = _methods.asStateFlow()
+
+    private val _category = MutableStateFlow<List<CategoryEntity>>(emptyList())
+    var category = _category.asStateFlow()
 
     // 수입/지출 내역 작성 시 필요한 데이터
     fun fetchAccount(postId: Long?) = viewModelScope.launch {
@@ -97,28 +102,14 @@ class PostViewModel(
             }
             null -> {}
         }
-        val methods = when (val methodResult = result.settingModel.methods) {
-            is Result.Error -> {
-                _postUIState.value =
-                    PostUiState.Error(R.string.error_account_get)
-                emptyList()
-            }
-            is Result.Success -> methodResult.data
+        when (val methodResult = result.settingModel.methods) {
+            is Result.Error -> {}
+            is Result.Success -> _methods.value = methodResult.data
         }
-        val categories = when (val categoryResult = result.settingModel.categories) {
-            is Result.Error -> {
-                _postUIState.value =
-                    PostUiState.Error(R.string.error_account_get)
-                emptyList()
-            }
-            is Result.Success -> categoryResult.data
+        when (val categoryResult = result.settingModel.categories) {
+            is Result.Error -> {}
+            is Result.Success -> _category.value = categoryResult.data
         }
-
-        _postUIState.value = PostUiState.Success.FetchAccount(
-            methods = methods,
-            incomeCategories = categories.filter { it.type == HistoryType.INCOME.type },
-            outcomeCategories = categories.filter { it.type == HistoryType.OUTCOME.type }
-        )
     }
 
     fun addAccount() = viewModelScope.launch {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,21 +39,19 @@ fun SettingScreen(
     viewModel: SettingViewModel,
     onPushNavigate: (String, String) -> Unit
 ) {
-    val observeData = viewModel.settingUiState.collectAsState()
-    when (val result = observeData.value) {
-        SettingUiState.UnInitialized -> viewModel.fetchData()
-        SettingUiState.Loading -> {}
-        is SettingUiState.Success -> {
-            Body(
-                methods = result.methods,
-                incomeCategories = result.incomeCategories,
-                outcomeCategories = result.outcomeCategories,
-                onPushNavigate = onPushNavigate
-            )
-        }
-        is SettingUiState.Error -> {}
+    LaunchedEffect(key1 = Unit) {
+        viewModel.fetchData()
     }
 
+    val methods = viewModel.methods.collectAsState()
+    val category = viewModel.category.collectAsState()
+
+    Body(
+        methods = methods.value,
+        incomeCategories = category.value.filter { it.type == HistoryType.INCOME.type },
+        outcomeCategories = category.value.filter { it.type == HistoryType.OUTCOME.type },
+        onPushNavigate = onPushNavigate
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
@@ -12,54 +12,31 @@ import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.model.method.MethodModel
 import com.seom.accountbook.model.setting.SettingModel
 import com.seom.accountbook.usecase.GetAllSettingDataUseCase
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class SettingViewModel(
     private val getAllSettingDataUseCase: GetAllSettingDataUseCase = GetAllSettingDataUseCase()
 ) : ViewModel() {
-    private val _settingUiState = MutableStateFlow<SettingUiState>(SettingUiState.UnInitialized)
-    val settingUiState: StateFlow<SettingUiState>
-        get() = _settingUiState
+    private val _methods = MutableStateFlow<List<MethodEntity>>(emptyList())
+    var methods = _methods.asStateFlow()
+
+    private val _category = MutableStateFlow<List<CategoryEntity>>(emptyList())
+    var category = _category.asStateFlow()
 
     fun fetchData() = viewModelScope.launch {
         val result = getAllSettingDataUseCase()
 
-        val methods = when (val methodResult = result.methods) {
-            is Result.Error -> {
-                _settingUiState.value = SettingUiState.Error(R.string.error_setting_method_get)
-                emptyList()
-            }
-            is Result.Success -> methodResult.data
+        when (val methodResult = result.methods) {
+            is Result.Error -> {}
+            is Result.Success -> _methods.value = methodResult.data
         }
-        val categories = when (val categoryResult = result.categories) {
-            is Result.Error -> {
-                _settingUiState.value = SettingUiState.Error(R.string.error_setting_category_get)
-                emptyList()
-            }
-            is Result.Success -> categoryResult.data
+        when (val categoryResult = result.categories) {
+            is Result.Error -> {}
+            is Result.Success -> _category.value = categoryResult.data
         }
-
-        _settingUiState.value = SettingUiState.Success(
-            methods = methods,
-            incomeCategories = categories.filter { it.type == HistoryType.INCOME.type },
-            outcomeCategories = categories.filter { it.type == HistoryType.OUTCOME.type }
-        )
     }
-}
-
-sealed interface SettingUiState {
-    object UnInitialized : SettingUiState
-    object Loading : SettingUiState
-    data class Success(
-        val methods: List<MethodEntity>,
-        val incomeCategories: List<CategoryEntity>,
-        val outcomeCategories: List<CategoryEntity>
-    ) : SettingUiState
-
-    data class Error(
-        @StringRes
-        val errorMsg: Int
-    ) : SettingUiState
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -33,24 +33,26 @@ fun CategoryAddScreen(
     viewModel: CategoryViewModel,
     onBackButtonPressed: () -> Unit
 ) {
-    val observeData = viewModel.categoryUiState.collectAsState()
-    when (observeData.value) {
-        CategoryUiState.UnInitialized -> viewModel.fetchCategory(
-            categoryId = categoryId?.toLong(),
-            categoryType = categoryType
-        )
-        CategoryUiState.Loading -> {}
-        CategoryUiState.Success.AddCategory -> onBackButtonPressed()
-        CategoryUiState.Success.FetchCategory -> SettingBody(
-            viewModel = viewModel,
-            isModifyMode = categoryId.isNullOrBlank().not(),
-            categoryType = categoryType,
-            onBackButtonPressed = onBackButtonPressed
-        )
-        is CategoryUiState.Error -> {}
+    LaunchedEffect(key1 = Unit) {
+        viewModel.categoryUiState.collect {
+            when (it) {
+                CategoryUiState.UnInitialized -> viewModel.fetchCategory(
+                    categoryId = categoryId?.toLong(),
+                    categoryType = categoryType
+                )
+                CategoryUiState.Loading -> {}
+                CategoryUiState.Success.AddCategory -> onBackButtonPressed()
+                CategoryUiState.Success.FetchCategory -> {}
+                is CategoryUiState.Error -> {}
+            }
+        }
     }
-
-
+    SettingBody(
+        viewModel = viewModel,
+        isModifyMode = categoryId.isNullOrBlank().not(),
+        categoryType = categoryType,
+        onBackButtonPressed = onBackButtonPressed
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -25,22 +25,29 @@ fun MethodAddScreen(
     viewModel: MethodViewModel,
     onBackButtonPressed: () -> Unit
 ) {
-    val observeData = viewModel.methodUiState.collectAsState()
-    when (observeData.value) {
-        MethodUiState.UnInitialized -> viewModel.fetchCategory(
-            methodId = methodId?.toLong()
-        )
-        MethodUiState.Loading -> {}
-        MethodUiState.Success.AddMethod -> onBackButtonPressed()
-        MethodUiState.Success.FetchMethod -> {
-            MethodBody(
-                isModifyMode = methodId.isNullOrBlank().not(),
-                viewModel = viewModel,
-                onBackButtonPressed = onBackButtonPressed
-            )
+    LaunchedEffect(key1 = Unit) {
+        viewModel.methodUiState.collect {
+            when (it) {
+                MethodUiState.UnInitialized -> viewModel.fetchCategory(
+                    methodId = methodId?.toLong()
+                )
+                MethodUiState.Loading -> {}
+                MethodUiState.Success.AddMethod -> {
+                    onBackButtonPressed()
+                }
+                MethodUiState.Success.FetchMethod -> {
+                }
+                is MethodUiState.Error -> {
+                    println("Error Method")
+                }
+            }
         }
-        is MethodUiState.Error -> {}
     }
+    MethodBody(
+        isModifyMode = methodId.isNullOrBlank().not(),
+        viewModel = viewModel,
+        onBackButtonPressed = onBackButtonPressed
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
@@ -59,7 +59,6 @@ class MethodViewModel(
         } ?: kotlin.run {
             methodRepository.addMethod(method)
         }
-
         when (result) {
             is Result.Error -> _methodUiState.value =
                 MethodUiState.Error(R.string.error_method_add)
@@ -71,9 +70,9 @@ class MethodViewModel(
 sealed interface MethodUiState {
     object UnInitialized : MethodUiState
     object Loading : MethodUiState
-    object Success {
-        object AddMethod : MethodUiState
-        object FetchMethod : MethodUiState
+    sealed interface Success: MethodUiState {
+        object AddMethod : Success
+        object FetchMethod : Success
     }
 
     data class Error(

--- a/app/src/main/java/com/seom/accountbook/ui/theme/Theme.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/theme/Theme.kt
@@ -17,17 +17,8 @@ private val LightColorPalette = lightColors(
     primary = ColorPalette.Purple,
     primaryVariant = ColorPalette.LightPurple,
     secondary = ColorPalette.Purple40,
-
     onPrimary = ColorPalette.White,
     background = ColorPalette.OffWhite
-    /* Other default colors to override
-    background = Color.White,
-    surface = Color.White,
-    onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
-    */
 )
 
 @Composable


### PR DESCRIPTION
### 📌 Summary
각 페이지에서 DB에 새로운 데이터를 추가하고, 이전 화면으로 돌아가는 도중 recomposition이 여러번 발생하는 문제가 발생
이를 수정하여 데이터 추가 이후 이전 화면으로 정상 이동하고 추가된 데이터가 화면에 반영되도록 수정 필요

### 🍿 Main Changes 
- 결제 수단 추가 성공 시, 설정 화면으로 이동
- 수입/지출 카테고리 추가 성공 시, 설정 화면으로 이동
- 설정 화면으로 돌아오면, 관련 데이터를 다시 데이터베이스에 요청
- 수입/지출 내역 추가 성공 시, 수입/지출 내역 화면(history 화면)으로 이동
- 수입/지출 내역 화면으로 돌아오면, 관련 데이터를 다시 데이터베이스에 요청

### 🔥 UseCase
1. 결제 수단 추가
2. 수입/지출 카테고리 추가
3. 수입/지출 내역 추가

### 🛠 Related Issue
Closes #36