### PR TITLE
Setting 화면(+ 결제수단, 카테고리 작성 화면) Component 정리 및 세부 기능 구현하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/AccountActivity.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountActivity.kt
@@ -40,6 +40,7 @@ fun AccountApp() {
     val currentScreen =
         allScreens.find { currentDestination?.route?.startsWith(it.route) ?: false } ?: History
 
+    println(currentDestination?.route)
     AccountBookTheme() {
         Scaffold(
             bottomBar = {

--- a/app/src/main/java/com/seom/accountbook/AccountActivity.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountActivity.kt
@@ -2,6 +2,7 @@ package com.seom.accountbook
 
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
@@ -22,6 +23,9 @@ class AccountActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // TODO DEPRECATED 된 거 수정하기
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 
         setContent {
             AccountApp()

--- a/app/src/main/java/com/seom/accountbook/AccountDestination.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountDestination.kt
@@ -1,7 +1,5 @@
 package com.seom.accountbook
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 
@@ -68,7 +66,7 @@ object Setting : AccountDestination {
     override val group = "setting"
 }
 
-object Method : AccountDestination {
+object MethodDestination : AccountDestination {
     override val icon = R.drawable.ic_settings
     override val route = "method"
     override val title = "결제수단"
@@ -81,7 +79,7 @@ object Method : AccountDestination {
     )
 }
 
-object Category : AccountDestination {
+object CategoryDestination : AccountDestination {
     override val icon = R.drawable.ic_settings
     override val route = "category"
     override val title = "카테고리"
@@ -100,5 +98,5 @@ object Category : AccountDestination {
     )
 }
 
-val allScreens = listOf(History, Post, Calendar, Graph, Detail, Setting, Method, Category)
+val allScreens = listOf(History, Post, Calendar, Graph, Detail, Setting, MethodDestination, CategoryDestination)
 val accountBottomTabScreens = listOf(History, Calendar, Graph, Setting)

--- a/app/src/main/java/com/seom/accountbook/data/entity/Result.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/Result.kt
@@ -1,6 +1,10 @@
 package com.seom.accountbook.data.entity
 
 sealed interface Result<out T : Any> {
-    data class Success<out T : Any>(val data: T) : Result<T>
+    sealed interface Success<out T : Any> : Result<T> {
+        data class Finish<out T : Any>(val data: T) : Success<T>
+        object Pause : Success<Nothing>
+    }
+
     data class Error(val exception: String) : Result<Nothing>
 }

--- a/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
@@ -1,10 +1,7 @@
 package com.seom.accountbook.data.local
 
 import android.content.ContentValues
-import android.provider.BaseColumns
-import com.seom.accountbook.data.entity.account.AccountEntity
 import com.seom.accountbook.data.entity.category.CategoryEntity
-import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.di.provideAppDatabase
 import com.seom.accountbook.model.history.HistoryType
 
@@ -37,9 +34,8 @@ class CategoryDao(
 
     fun addCategory(category: CategoryEntity): Long? {
         val db = appDatabase.writable
-        if (checkCategoryName(category.name)) {
-            println("check category name")
-            return null
+        if (checkCategoryName(category.name, category.type)) {
+            return -1
         }
         val values = ContentValues().apply {
             put(CategoryEntity.COLUMN_NAME_NAME, category.name)
@@ -108,14 +104,14 @@ class CategoryDao(
         return categories.toList()
     }
 
-    private fun checkCategoryName(name: String): Boolean {
+    private fun checkCategoryName(name: String, type: Int): Boolean {
         val db = appDatabase.readable
 
         val projection = arrayOf(
             CategoryEntity.COLUMN_NAME_ID
         )
-        val selection = "${CategoryEntity.COLUMN_NAME_NAME} = ?"
-        val selectionArgs = arrayOf(name)
+        val selection = "${CategoryEntity.COLUMN_NAME_NAME} = ? AND ${CategoryEntity.COLUMN_NAME_TYPE} = ?"
+        val selectionArgs = arrayOf(name, type.toString())
 
         val cursor = db.query(
             TABLE_NAME,

--- a/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
@@ -25,11 +25,39 @@ class MethodDao(
 
     fun addMethod(method: MethodEntity): Long? {
         val db = appDatabase.writable
+        if (checkMethodName(method.name)) {
+            return -1
+        }
         val values = ContentValues().apply {
             put(MethodEntity.COLUMN_NAME_NAME, method.name)
         }
 
         return db?.insert(TABLE_NAME, null, values)
+    }
+
+    private fun checkMethodName(name: String): Boolean {
+        val db = appDatabase.readable
+
+        val projection = arrayOf(
+            MethodEntity.COLUMN_NAME_ID
+        )
+        val selection = "${MethodEntity.COLUMN_NAME_NAME} = ?"
+        val selectionArgs = arrayOf(name)
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs,
+            null, null, null,
+            "1"
+        )
+
+        return cursor?.use {
+            cursor.moveToFirst()
+        } ?: kotlin.run {
+            false
+        }
     }
 
     fun getAllMethods(): List<MethodEntity> {

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
@@ -22,7 +22,7 @@ class AccountRepositoryImpl(
         try {
             val id = accountDao.addAccount(account)
 
-            if (id != null) Result.Success(id)
+            if (id != null) Result.Success.Finish(id)
             else throw Exception("")
         } catch (exception: Exception) {
             Result.Error(exception.toString())
@@ -33,7 +33,7 @@ class AccountRepositoryImpl(
         try {
             val account = accountDao.getAccount(id)
 
-            if (account != null) Result.Success(account)
+            if (account != null) Result.Success.Finish(account)
             else throw Exception("")
         } catch (exception: Exception) {
             Result.Error(exception.toString())
@@ -45,7 +45,7 @@ class AccountRepositoryImpl(
             try {
                 val result = accountDao.updateAccount(account)
 
-                if (result > 0) Result.Success(result)
+                if (result > 0) Result.Success.Finish(result)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -56,7 +56,7 @@ class AccountRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val result = accountDao.getAllAccountByDate(year, month)
-                Result.Success(result)
+                Result.Success.Finish(result)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }
@@ -66,7 +66,7 @@ class AccountRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val deletedRowNum = accountDao.removeAccount(accountItems)
-                Result.Success(deletedRowNum)
+                Result.Success.Finish(deletedRowNum)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }
@@ -76,7 +76,7 @@ class AccountRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val result = accountDao.getAllAccountOnDate(year, month)
-                Result.Success(result)
+                Result.Success.Finish(result)
             } catch (exception: Exception) {
                 println(exception.toString())
                 Result.Error(exception.toString())
@@ -89,7 +89,7 @@ class AccountRepositoryImpl(
     ): Result<List<OutComeByCategory>> = withContext(ioDispatcher) {
         try {
             val result = accountDao.getOutComeOnCategory(year, month)
-            Result.Success(result)
+            Result.Success.Finish(result)
         } catch (exception: Exception) {
             println(exception.toString())
             Result.Error(exception.toString())
@@ -103,7 +103,7 @@ class AccountRepositoryImpl(
     ): Result<List<OutComeByMonth>> = withContext(ioDispatcher) {
         try {
             val result = accountDao.getOutComeOnMonth(categoryId, year, month)
-            Result.Success(result)
+            Result.Success.Finish(result)
         } catch (exception: Exception) {
             println(exception.toString())
             Result.Error(exception.toString())
@@ -117,7 +117,7 @@ class AccountRepositoryImpl(
     ): Result<List<HistoryModel>>  = withContext(ioDispatcher) {
         try {
             val result = accountDao.getDetailOutComeOnCategory(categoryId, year, month)
-            Result.Success(result)
+            Result.Success.Finish(result)
         } catch (exception: Exception) {
             println(exception.toString())
             Result.Error(exception.toString())

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
@@ -18,8 +18,10 @@ class CategoryRepositoryImpl(
             try {
                 val categoryId = categoryDao.addCategory(category)
 
-                if (categoryId != null) Result.Success(categoryId)
-                else throw Exception("")
+                if (categoryId != null) {
+                    if (categoryId == -1L) Result.Success.Pause
+                    else Result.Success.Finish(categoryId)
+                } else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }
@@ -30,7 +32,7 @@ class CategoryRepositoryImpl(
             try {
                 val result = categoryDao.updateCategory(category)
 
-                if (result > 0) Result.Success(result)
+                if (result > 0) Result.Success.Finish(result)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -42,7 +44,7 @@ class CategoryRepositoryImpl(
             try {
                 val category = categoryDao.getCategory(id)
 
-                if (category != null) Result.Success(category)
+                if (category != null) Result.Success.Finish(category)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -53,7 +55,7 @@ class CategoryRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val categories = categoryDao.getAllCategory()
-                Result.Success(categories)
+                Result.Success.Finish(categories)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
@@ -19,7 +19,7 @@ class MethodRepositoryImpl(
             try {
                 val methodId = methodDao.addMethod(method)
 
-                if (methodId != null) Result.Success(methodId)
+                if (methodId != null) Result.Success.Finish(methodId)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -31,7 +31,7 @@ class MethodRepositoryImpl(
             try {
                 val result = methodDao.updateMethod(method)
 
-                if (result > 0) Result.Success(result)
+                if (result > 0) Result.Success.Finish(result)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -43,7 +43,7 @@ class MethodRepositoryImpl(
             try {
                 val category = methodDao.getMethods(id)
 
-                if (category != null) Result.Success(category)
+                if (category != null) Result.Success.Finish(category)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
@@ -54,7 +54,7 @@ class MethodRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val methods = methodDao.getAllMethods()
-                Result.Success(methods)
+                Result.Success.Finish(methods)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
@@ -19,8 +19,10 @@ class MethodRepositoryImpl(
             try {
                 val methodId = methodDao.addMethod(method)
 
-                if (methodId != null) Result.Success.Finish(methodId)
-                else throw Exception("")
+                if (methodId != null) {
+                    if (methodId == -1L) Result.Success.Pause
+                    else Result.Success.Finish(methodId)
+                } else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }

--- a/app/src/main/java/com/seom/accountbook/ui/components/appbar/NoneButtonAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/appbar/NoneButtonAppBar.kt
@@ -1,0 +1,40 @@
+package com.seom.accountbook.ui.components.appbar
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * text 만 있는 app bar
+ */
+@Composable
+fun NoneButtonAppBar(
+    title: String
+) {
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CustomText(
+                text = title,
+                style = MaterialTheme.typography.body1,
+                bold = false,
+                color = ColorPalette.Purple
+            )
+        }
+
+        BaseDivider(color = ColorPalette.Purple)
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/appbar/OneButtonAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/appbar/OneButtonAppBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
+import com.seom.accountbook.ui.components.common.BaseDivider
 import com.seom.accountbook.ui.theme.ColorPalette
 
 /**
@@ -22,7 +23,7 @@ fun OneButtonAppBar(
     title: String,
     leftIcon: @Composable () -> Unit
 ) {
-    Column() {
+    Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -38,10 +39,7 @@ fun OneButtonAppBar(
             Spacer(modifier = Modifier.width(24.dp))
         }
 
-        Divider(
-            color = ColorPalette.Purple,
-            thickness = 1.dp
-        )
+        BaseDivider(color = ColorPalette.Purple)
     }
 }
 

--- a/app/src/main/java/com/seom/accountbook/ui/components/common/BaseDivider.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/common/BaseDivider.kt
@@ -1,0 +1,20 @@
+package com.seom.accountbook.ui.components.common
+
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * Lazy Column 에 사용되는 Divider
+ */
+@Composable
+fun BaseDivider(
+    color: Color
+) {
+    Divider(
+        color = color,
+        thickness = 1.dp
+    )
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/common/BaseSnackBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/common/BaseSnackBar.kt
@@ -1,0 +1,34 @@
+package com.seom.accountbook.ui.components.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+
+@Composable
+fun SnackbarHostState.BaseSnackBar(
+    hostState: SnackbarHostState
+) {
+    SnackbarHost(
+        hostState = hostState
+    ) { data ->
+        Snackbar(
+            modifier = Modifier
+                .padding(16.dp),
+            backgroundColor = ColorPalette.SnackBar,
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            CustomText(
+                text = data.message,
+                style = MaterialTheme.typography.subtitle1,
+                bold = true,
+                color = ColorPalette.White
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/common/Chip.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/common/Chip.kt
@@ -1,0 +1,40 @@
+package com.seom.accountbook.ui.components.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+
+@Composable
+fun Chip(
+    text: String,
+    color: Color
+) {
+    CustomText(
+        text = text,
+        style = MaterialTheme.typography.caption,
+        bold = true,
+        color = ColorPalette.White,
+        align = TextAlign.Center,
+        modifier = Modifier
+            .widthIn(56.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(color)
+            .padding(
+                start = 8.dp,
+                top = 4.dp,
+                bottom = 4.dp,
+                end = 8.dp
+            )
+    )
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/common/ListBottomSpacer.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/common/ListBottomSpacer.kt
@@ -1,0 +1,22 @@
+package com.seom.accountbook.ui.components.common
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.Divider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * 리스트 바닥 공간
+ */
+fun LazyListScope.BottomSpacer(
+    height: Int
+) {
+    item {
+        BaseDivider(color = ColorPalette.LightPurple)
+        Spacer(modifier = Modifier.height(height.dp))
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/container/BottomButtonBox.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/container/BottomButtonBox.kt
@@ -1,0 +1,59 @@
+package com.seom.accountbook.ui.components.container
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * 하단에 버튼이 있는 Box Layout
+ */
+@Composable
+fun BottomButtonBox(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    buttonText: String,
+    buttonColor: Color,
+    disabledColor: Color = buttonColor,
+    onClickBtn: () -> Unit,
+    body: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+    ) {
+        body()
+        Button(
+            onClick = onClickBtn,
+            enabled = enabled,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = buttonColor,
+                disabledBackgroundColor = disabledColor
+            ),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, bottom = 40.dp)
+                .clip(RoundedCornerShape(16.dp))
+        ) {
+            CustomText(
+                text = buttonText,
+                style = MaterialTheme.typography.subtitle1,
+                bold = true,
+                color = ColorPalette.White,
+                paddingVertical = 8,
+                modifier = Modifier
+                    .background(Color.Transparent)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
@@ -1,0 +1,40 @@
+package com.seom.accountbook.ui.components.header
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * 왼쪽에 글씨 하나만 있는 Header
+ */
+@Composable
+fun SingleTextHeader(
+    title: String
+) {
+    Column(
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            bottom = 8.dp,
+            top = 8.dp
+        )
+    ) {
+        CustomText(
+            text = title,
+            style = MaterialTheme.typography.body2,
+            bold = false,
+            color = ColorPalette.LightPurple
+        )
+        Divider(
+            color = ColorPalette.Purple40,
+            thickness = 1.dp
+        )
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
@@ -1,6 +1,8 @@
 package com.seom.accountbook.ui.components.header
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
@@ -19,22 +21,22 @@ fun SingleTextHeader(
     title: String
 ) {
     Column(
-        modifier = Modifier.padding(
-            start = 16.dp,
-            end = 16.dp,
-            bottom = 8.dp,
-            top = 8.dp
-        )
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(ColorPalette.OffWhite)
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 16.dp
+            )
     ) {
         CustomText(
             text = title,
             style = MaterialTheme.typography.body2,
             bold = false,
-            color = ColorPalette.LightPurple
-        )
-        Divider(
-            color = ColorPalette.Purple40,
-            thickness = 1.dp
+            color = ColorPalette.LightPurple,
+            modifier = Modifier
+                .padding(top = 8.dp, bottom = 8.dp)
         )
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/image/IconImage.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/image/IconImage.kt
@@ -1,0 +1,24 @@
+package com.seom.accountbook.ui.components.image
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+
+/**
+ * 색 지정이 가능한 Image
+ */
+@Composable
+fun IconImage(
+    @DrawableRes
+    icon: Int,
+    color: Color
+) {
+    Image(
+        painter = painterResource(id = icon),
+        contentDescription = null,
+        colorFilter = ColorFilter.tint(color)
+    )
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/selector/ColorSelector.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/selector/ColorSelector.kt
@@ -1,0 +1,46 @@
+package com.seom.accountbook.ui.components.selector
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.math.min
+
+@Composable
+fun ColorSelector(
+    colors: List<Long>,
+    perLine: Int,
+    selectedColor: Long,
+    modifier: Modifier = Modifier,
+    onSelectItem: (Long) -> Unit
+) {
+    var rowNum = colors.size / perLine
+    if (colors.size % perLine != 0)
+        rowNum++
+
+    Column(modifier.padding(16.dp)) {
+        (0 until rowNum).forEachIndexed { _, row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                (0 until min(perLine, colors.size)).forEachIndexed { _, column ->
+                    val color = colors[row * perLine + column]
+                    val paddingAnimation by animateDpAsState(targetValue = if (color == selectedColor) 0.dp else 4.dp)
+                    Spacer(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .padding(paddingAnimation)
+                            .background(Color(color))
+                            .clickable { onSelectItem(color) }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/selector/ColorSelector.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/selector/ColorSelector.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.theme.ColorPalette
 import kotlin.math.min
 
 @Composable
@@ -23,7 +25,13 @@ fun ColorSelector(
     if (colors.size % perLine != 0)
         rowNum++
 
-    Column(modifier.padding(16.dp)) {
+    Column(modifier.padding(
+        start = 16.dp,
+        end = 16.dp,
+        bottom = 16.dp
+    )) {
+        BaseDivider(color = ColorPalette.Purple40)
+        Spacer(modifier = Modifier.height(16.dp))
         (0 until rowNum).forEachIndexed { _, row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
@@ -1,0 +1,41 @@
+package com.seom.accountbook.ui.components.text
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Text
+ */
+@Composable
+fun CustomText(
+    text: String,
+    style: TextStyle,
+    bold: Boolean,
+    color: Color,
+    modifier: Modifier = Modifier,
+    paddingVertical: Int = 0,
+    paddingHorizontal: Int = 0
+) {
+    Text(
+        text = text,
+        style = style,
+        fontWeight = FontWeight(if (bold) FONT_WEIGHT_BOLD else FONT_WEIGHT_LIGHT),
+        color = color,
+        modifier = modifier
+            .padding(
+                start = paddingHorizontal.dp,
+                top = paddingVertical.dp,
+                end = paddingHorizontal.dp,
+                bottom = paddingVertical.dp
+            )
+    )
+}
+
+const val FONT_WEIGHT_BOLD = 700
+const val FONT_WEIGHT_LIGHT = 500

--- a/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 /**
@@ -14,11 +15,12 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun CustomText(
+    modifier: Modifier = Modifier,
     text: String,
     style: TextStyle,
     bold: Boolean,
     color: Color,
-    modifier: Modifier = Modifier,
+    align: TextAlign = TextAlign.Start,
     paddingVertical: Int = 0,
     paddingHorizontal: Int = 0
 ) {
@@ -27,6 +29,7 @@ fun CustomText(
         style = style,
         fontWeight = FontWeight(if (bold) FONT_WEIGHT_BOLD else FONT_WEIGHT_LIGHT),
         color = color,
+        textAlign = align,
         modifier = modifier
             .padding(
                 start = paddingHorizontal.dp,

--- a/app/src/main/java/com/seom/accountbook/ui/components/text/CustomTextField.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/text/CustomTextField.kt
@@ -1,0 +1,68 @@
+package com.seom.accountbook.ui.components.text
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * Custom Input Field
+ */
+@Composable
+fun CustomTextField(
+    modifier: Modifier = Modifier,
+    name: String,
+    value: String,
+    textColor: Color,
+    onValueChanged: (String) -> Unit
+) {
+    Column(
+        modifier = modifier
+    ) {
+        Row(modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)) {
+            CustomText(
+                text = name,
+                style = MaterialTheme.typography.subtitle1,
+                bold = false,
+                color = textColor,
+                modifier = Modifier.weight(2f)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Surface(
+                modifier = Modifier.weight(8f),
+                color = Color.Transparent
+            ) {
+                Box {
+                    BasicTextField(
+                        value = value,
+                        onValueChange = onValueChanged,
+                        textStyle = MaterialTheme.typography.subtitle1.copy(color = textColor),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    if (value.isBlank()) {
+                        CustomText(
+                            text = "입력하세요",
+                            style = MaterialTheme.typography.subtitle1,
+                            bold = true,
+                            color = ColorPalette.LightPurple
+                        )
+                    }
+                }
+            }
+        }
+        Divider(
+            color = ColorPalette.Purple40,
+            thickness = 1.dp
+        )
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
@@ -24,7 +24,7 @@ class CalendarViewModel(
         when (val result = accountRepository.getAllAccountOnDate(year, month)) {
             is Result.Error -> _categoryUiState.value =
                 CalendarUiState.Error(R.string.error_history_get)
-            is Result.Success -> _categoryUiState.value =
+            is Result.Success.Finish -> _categoryUiState.value =
                 CalendarUiState.SuccessFetch(result.data)
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
@@ -23,16 +23,15 @@ class DetailViewModel(
 
     fun fetchData(categoryId: Long, year: Int, month: Int) = viewModelScope.launch {
         _detailUiState.value = DetailUiState.Loading
-        println("************")
         val result = getDetailOutComeOnCategory(categoryId,year,month)
 
         val outComeByMonth = when(val data = result.outComeOnMonth) {
-            is Result.Error -> emptyList()
-            is Result.Success -> data.data
+            is Result.Success.Finish -> data.data
+            else -> emptyList()
         }
         val accounts = when(val data = result.accounts) {
-            is Result.Error -> emptyList()
-            is Result.Success -> data.data
+            is Result.Success.Finish-> data.data
+            else -> emptyList()
         }
         _detailUiState.value = DetailUiState.SuccessFetch(
             outComeByMonth = outComeByMonth,

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
@@ -29,7 +29,7 @@ class GraphViewModel(
         when (val result = accountRepository.getOutComeOnCategory(year, month)) {
             is Result.Error -> _graphUiState.value =
                 GraphUiState.Error(R.string.error_history_get)
-            is Result.Success -> {
+            is Result.Success.Finish -> {
                 currentYear = year
                 currentMonth = month
                 _graphUiState.value =

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryViewModel.kt
@@ -33,14 +33,14 @@ class HistoryViewModel(
     fun fetchData(year: Int, month: Int) = viewModelScope.launch {
         when (val result = accountRepository.getAllAccountByDate(year, month)) {
             is Result.Error -> {}
-            is Result.Success -> _histories.value = result.data
+            is Result.Success.Finish -> _histories.value = result.data
         }
     }
 
     fun removeItems() = viewModelScope.launch {
         when (accountRepository.removeAccounts(selectedItem)) {
             is Result.Error -> {}
-            is Result.Success -> {
+            is Result.Success.Finish -> {
                 _histories.value = _histories.value.filter { (it.id in selectedItem).not() }
                 selectedItem.clear()
             }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
@@ -26,24 +26,21 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import com.seom.accountbook.Category
-import com.seom.accountbook.Method
+import com.seom.accountbook.CategoryDestination
+import com.seom.accountbook.MethodDestination
 import com.seom.accountbook.R
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.model.BaseModel
 import com.seom.accountbook.model.category.CategoryModel
 import com.seom.accountbook.model.history.HistoryType
-import com.seom.accountbook.model.method.MethodModel
 import com.seom.accountbook.ui.components.BackButtonAppBar
 import com.seom.accountbook.ui.components.CustomBottomSheet
 import com.seom.accountbook.ui.components.datesheet.FullDateBottomSheet
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.*
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.util.*
 
 /**
  * 수입/지출 내역 화면 UI
@@ -277,7 +274,7 @@ fun PostBody(
                         onOptionSelected = onChangeMethodId,
                         onPushAddButton = {
                             onPushNavigation(
-                                Method.route,
+                                MethodDestination.route,
                                 ""
                             )
                         },
@@ -291,7 +288,7 @@ fun PostBody(
                     onOptionSelected = onChangeCategoryId,
                     onPushAddButton = {
                         onPushNavigation(
-                            Category.route,
+                            CategoryDestination.route,
                             "${currentSelectedTab.value.type}"
                         )
                     },

--- a/app/src/main/java/com/seom/accountbook/ui/screen/post/PostViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/post/PostViewModel.kt
@@ -90,7 +90,7 @@ class PostViewModel(
         when (val accountResult = result.account) {
             is Result.Error -> _postUIState.value =
                 PostUiState.Error(R.string.error_account_get)
-            is Result.Success -> {
+            is Result.Success.Finish -> {
                 val account = accountResult.data
                 accountId = account.id
                 _type.value = HistoryType.getHistoryType(account.type)
@@ -104,11 +104,11 @@ class PostViewModel(
         }
         when (val methodResult = result.settingModel.methods) {
             is Result.Error -> {}
-            is Result.Success -> _methods.value = methodResult.data
+            is Result.Success.Finish -> _methods.value = methodResult.data
         }
         when (val categoryResult = result.settingModel.categories) {
             is Result.Error -> {}
-            is Result.Success -> _category.value = categoryResult.data
+            is Result.Success.Finish -> _category.value = categoryResult.data
         }
     }
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -3,36 +3,37 @@
 package com.seom.accountbook.ui.screen.setting
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.seom.accountbook.R
+import com.seom.accountbook.AccountDestination
+import com.seom.accountbook.CategoryDestination
+import com.seom.accountbook.MethodDestination
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
-import com.seom.accountbook.model.category.CategoryModel
+import com.seom.accountbook.model.BaseModel
 import com.seom.accountbook.model.history.HistoryType
-import com.seom.accountbook.model.method.MethodModel
+import com.seom.accountbook.ui.components.appbar.NoneButtonAppBar
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.common.BottomSpacer
+import com.seom.accountbook.ui.components.header.SingleTextHeader
+import com.seom.accountbook.ui.components.text.CustomText
 import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.R
+import com.seom.accountbook.ui.components.common.Chip
+import com.seom.accountbook.ui.components.image.IconImage
 
 @Composable
 fun SettingScreen(
@@ -46,7 +47,7 @@ fun SettingScreen(
     val methods = viewModel.methods.collectAsState()
     val category = viewModel.category.collectAsState()
 
-    Body(
+    SettingBody(
         methods = methods.value,
         incomeCategories = category.value.filter { it.type == HistoryType.INCOME.type },
         outcomeCategories = category.value.filter { it.type == HistoryType.OUTCOME.type },
@@ -55,7 +56,7 @@ fun SettingScreen(
 }
 
 @Composable
-fun Body(
+fun SettingBody(
     methods: List<MethodEntity>,
     incomeCategories: List<CategoryEntity>,
     outcomeCategories: List<CategoryEntity>,
@@ -63,197 +64,106 @@ fun Body(
 ) {
     Scaffold(
         topBar = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = "설정",
-                    style = MaterialTheme.typography.body1.copy(color = ColorPalette.Purple)
-                )
-            }
+            NoneButtonAppBar(title = "설정")
         }
     ) {
-        Column {
-            Divider(
-                color = ColorPalette.Purple,
-                thickness = 1.dp
+        LazyColumn {
+            SettingGroup(
+                items = methods,
+                itemName = "결제수단",
+                destination = MethodDestination,
+                onPushNavigate = onPushNavigate
             )
-
-            LazyColumn {
-                stickyHeader { Header(title = "결제수단") }
-                items(items = methods) {
-                    MethodItem(method = it) {
-                        onPushNavigate(
-                            com.seom.accountbook.Method.route,
-                            it.toString()
-                        )
-                    }
-                }
-                item {
-                    AddItem(itemName = "결제수단") {
-                        onPushNavigate(
-                            com.seom.accountbook.Method.route,
-                            ""
-                        )
-                    }
-                }
-                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
-                stickyHeader { Header(title = "지출 카테고리") }
-                items(items = outcomeCategories) {
-                    CategoryItem(category = it) {
-                        onPushNavigate(
-                            com.seom.accountbook.Category.route,
-                            "${HistoryType.OUTCOME.type}/$it"
-                        )
-                    }
-                }
-                item {
-                    AddItem(itemName = "지출 카테고리") {
-                        onPushNavigate(
-                            com.seom.accountbook.Category.route,
-                            "${HistoryType.OUTCOME.type}"
-                        )
-                    }
-                }
-                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
-                stickyHeader { Header(title = "수입 카테고리") }
-                items(items = incomeCategories) {
-                    CategoryItem(category = it) {
-                        onPushNavigate(
-                            com.seom.accountbook.Category.route,
-                            "${HistoryType.INCOME.type}/$it"
-                        )
-                    }
-                }
-                item {
-                    AddItem(itemName = "수입 카테고리") {
-                        onPushNavigate(
-                            com.seom.accountbook.Category.route,
-                            "${HistoryType.INCOME.type}"
-                        )
-                    }
-                }
-                item {
-                    Divider(
-                        color = ColorPalette.LightPurple,
-                        thickness = 1.dp
+            SettingGroup(
+                items = outcomeCategories,
+                itemName = "지출 카테고리",
+                destination = CategoryDestination,
+                onPushNavigate = { route, id ->
+                    onPushNavigate(
+                        route, "${HistoryType.OUTCOME.type}${if (id.isBlank()) "" else "/$id"}"
                     )
-                    Spacer(modifier = Modifier.height(40.dp))
+                },
+                rightChild = {
+                    (it as? CategoryEntity)?.let { category ->
+                        Chip(text = category.name, color = Color(category.color))
+                    }
                 }
-            }
+            )
+            SettingGroup(
+                items = incomeCategories,
+                itemName = "수입 카테고리",
+                destination = CategoryDestination,
+                onPushNavigate = { route, id ->
+                    onPushNavigate(
+                        route, "${HistoryType.INCOME.type}${if (id.isBlank()) "" else "/$id"}"
+                    )
+                },
+                rightChild = {
+                    (it as? CategoryEntity)?.let { category ->
+                        Chip(text = category.name, color = Color(category.color))
+                    }
+                }
+            )
+            BottomSpacer(40)
         }
     }
 }
 
-@Composable
-fun Header(
-    title: String
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(ColorPalette.OffWhite)
-            .padding(start = 16.dp, top = 24.dp, end = 16.dp, bottom = 8.dp)
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.body2.copy(color = ColorPalette.LightPurple)
-        )
-    }
-}
-
-@Composable
-fun MethodItem(
-    method: MethodEntity,
-    onClickItem: (Long?) -> Unit
-) {
-    Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
-    ) {
-        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp, bottom = 12.dp)
-                .clickable { onClickItem(method.id) },
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = method.name,
-                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
-            )
-        }
-    }
-}
-
-@Composable
-fun CategoryItem(
-    category: CategoryEntity,
-    onClickItem: (Long?) -> Unit
-) {
-    Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
-    ) {
-        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp, bottom = 12.dp)
-                .clickable { onClickItem(category.id) },
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = category.name,
-                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
-            )
-            Text(
-                text = category.name,
-                style = MaterialTheme.typography.subtitle2.copy(
-                    fontWeight = FontWeight(700),
-                    color = ColorPalette.White
-                ),
-                modifier = Modifier
-                    .widthIn(56.dp)
-                    .clip(RoundedCornerShape(999.dp))
-                    .background(Color(category.color))
-                    .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
-                textAlign = TextAlign.Center
-            )
-        }
-    }
-}
-
-@Composable
-fun AddItem(
+fun LazyListScope.SettingGroup(
+    items: List<BaseModel>,
     itemName: String,
-    onClickAddButton: () -> Unit
+    rightChild: @Composable (BaseModel) -> Unit = {},
+    destination: AccountDestination,
+    onPushNavigate: (String, String) -> Unit
+) {
+    stickyHeader { SingleTextHeader(title = itemName) }
+    items(items = items) { item ->
+        SettingItem(
+            itemName = item.name,
+            onClickItem = {
+                onPushNavigate(destination.route, item.id?.toString() ?: "")
+            }
+        ) {
+            rightChild(item)
+        }
+    }
+    item {
+        SettingItem(
+            itemName = "$itemName 추가하기",
+            onClickItem = { onPushNavigate(destination.route, "") }
+        ) {
+            IconImage(icon = R.drawable.ic_plus, color = ColorPalette.Purple)
+        }
+        Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
+    }
+}
+
+@Composable
+fun SettingItem(
+    itemName: String,
+    onClickItem: () -> Unit,
+    rightChild: @Composable () -> Unit = {}
 ) {
     Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+        modifier = Modifier
+            .padding(start = 16.dp, end = 10.dp)
     ) {
-        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+        BaseDivider(color = ColorPalette.Purple40)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 12.dp)
-                .clickable { onClickAddButton() },
+                .clickable { onClickItem() },
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = "$itemName 추가하기",
-                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            CustomText(
+                text = itemName,
+                style = MaterialTheme.typography.subtitle1,
+                bold = true,
+                color = ColorPalette.Purple
             )
-            Image(
-                painter = painterResource(id = R.drawable.ic_plus),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(color = ColorPalette.Purple)
-            )
+            rightChild()
         }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
@@ -32,11 +32,11 @@ class SettingViewModel(
 
         when (val methodResult = result.methods) {
             is Result.Error -> {}
-            is Result.Success -> _methods.value = methodResult.data
+            is Result.Success.Finish -> _methods.value = methodResult.data
         }
         when (val categoryResult = result.categories) {
             is Result.Error -> {}
-            is Result.Success -> _category.value = categoryResult.data
+            is Result.Success.Finish -> _category.value = categoryResult.data
         }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -1,30 +1,17 @@
 package com.seom.accountbook.ui.screen.setting.category
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
-import com.seom.accountbook.R
-import com.seom.accountbook.model.category.incomeColor
-import com.seom.accountbook.model.category.outcomeColor
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.BackButtonAppBar
-import com.seom.accountbook.ui.components.OneButtonAppBar
-import com.seom.accountbook.ui.screen.setting.method.Input
-import com.seom.accountbook.ui.screen.setting.method.InputField
+import com.seom.accountbook.ui.components.container.BottomButtonBox
+import com.seom.accountbook.ui.components.header.SingleTextHeader
+import com.seom.accountbook.ui.components.selector.ColorSelector
+import com.seom.accountbook.ui.components.text.CustomTextField
 import com.seom.accountbook.ui.theme.ColorPalette
-import kotlin.math.min
 
 @Composable
 fun CategoryAddScreen(
@@ -48,25 +35,32 @@ fun CategoryAddScreen(
         }
     }
     SettingBody(
-        viewModel = viewModel,
         isModifyMode = categoryId.isNullOrBlank().not(),
+        colorList = viewModel.colorList,
         categoryType = categoryType,
+        name = viewModel.name.collectAsState().value,
+        color = viewModel.color.collectAsState().value,
+        onChangeName = viewModel::setName,
+        onChangeColor = viewModel::setColor,
+        onClickAddBtn = viewModel::addCategory,
         onBackButtonPressed = onBackButtonPressed
     )
 }
 
 @Composable
 fun SettingBody(
-    viewModel: CategoryViewModel,
     isModifyMode: Boolean,
+    colorList: List<Long>,
     categoryType: HistoryType,
-    onBackButtonPressed: ()->Unit
+    name: String,
+    color: Long,
+    onChangeName: (String) -> Unit,
+    onChangeColor: (Long) -> Unit,
+    onClickAddBtn: () -> Unit,
+    onBackButtonPressed: () -> Unit
 ) {
     val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
     val modeTitle = if (isModifyMode) "추가하기" else "수정하기"
-
-    val name = viewModel.name.collectAsState()
-    val color = viewModel.color.collectAsState()
 
     Scaffold(topBar = {
         BackButtonAppBar(
@@ -74,94 +68,36 @@ fun SettingBody(
             onClickBackBtn = onBackButtonPressed
         )
     }) {
-        Box(
+        BottomButtonBox(
+            onClickBtn = onClickAddBtn,
+            enabled = name.isBlank().not(),
+            buttonText = "등록하기",
+            buttonColor = ColorPalette.Yellow,
+            disabledColor = ColorPalette.Yellow50,
             modifier = Modifier.fillMaxSize()
         ) {
             Column {
-                InputField(title = "이름") {
-                    Input(content = name.value, onValueChange = viewModel::setName)
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-                Column(
+                CustomTextField(
+                    name = "이름",
+                    value = name,
+                    textColor = ColorPalette.Purple,
+                    onValueChanged = onChangeName,
                     modifier = Modifier.padding(
-                        start = 16.dp,
-                        end = 16.dp
+                        start = 20.dp,
+                        end = 20.dp,
+                        top = 16.dp
                     )
-                ) {
-                    Text(
-                        text = "색상",
-                        style = MaterialTheme.typography.body2.copy(color = ColorPalette.LightPurple),
-                        modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
-                    )
-                    Divider(color = ColorPalette.Purple40, thickness = 1.dp)
-                }
-
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                SingleTextHeader(title = "색상")
                 ColorSelector(
-                    colors = viewModel.colorList,
+                    colors = colorList,
                     perLine = 10,
-                    selectedColor = color.value,
-                    onSelectItem = viewModel::setColor
+                    selectedColor = color,
+                    onSelectItem = onChangeColor
                 )
                 Spacer(modifier = Modifier.height(5.dp))
                 Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
-            }
-
-            Button(
-                onClick = viewModel::addCategory,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 40.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = ColorPalette.Yellow,
-                    disabledBackgroundColor = ColorPalette.Yellow50
-                ),
-                enabled = name.value.isBlank().not()
-            ) {
-                Text(
-                    text = "등록하기",
-                    style = MaterialTheme.typography.caption.copy(
-                        fontWeight = FontWeight(700),
-                        color = ColorPalette.White
-                    ),
-                    modifier = Modifier
-                        .padding(top = 8.dp, bottom = 8.dp)
-                        .background(Color.Transparent),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun ColorSelector(
-    colors: List<Long>,
-    perLine: Int,
-    selectedColor: Long,
-    modifier: Modifier = Modifier,
-    onSelectItem: (Long) -> Unit
-) {
-    var rowNum = colors.size / perLine
-    if (colors.size % perLine != 0)
-        rowNum++
-
-    Column(modifier.padding(16.dp)) {
-        (0 until rowNum).forEachIndexed { _, row ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceAround
-            ) {
-                (0 until min(perLine, colors.size)).forEachIndexed { _, column ->
-                    val color = colors[row * perLine + column]
-                    val paddingAnimation by animateDpAsState(targetValue = if (color == selectedColor) 0.dp else 4.dp)
-                    Spacer(
-                        modifier = Modifier
-                            .size(24.dp)
-                            .padding(paddingAnimation)
-                            .background(Color(color))
-                            .clickable { onSelectItem(color) }
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -88,7 +88,6 @@ fun SettingBody(
                         top = 16.dp
                     )
                 )
-                Spacer(modifier = Modifier.height(16.dp))
                 SingleTextHeader(title = "색상")
                 ColorSelector(
                     colors = colorList,
@@ -96,7 +95,6 @@ fun SettingBody(
                     selectedColor = color,
                     onSelectItem = onChangeColor
                 )
-                Spacer(modifier = Modifier.height(5.dp))
                 Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
             }
         }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
@@ -73,7 +73,7 @@ class CategoryViewModel(
             id = currentCategoryId,
             name = name.value,
             color = color.value,
-            type = currentCategoryType.type ?: HistoryType.INCOME.type
+            type = currentCategoryType.type
         )
 
         val result = currentCategoryId?.let {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -1,22 +1,13 @@
 package com.seom.accountbook.ui.screen.setting.method
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.seom.accountbook.R
-import com.seom.accountbook.ui.components.OneButtonAppBar
-import com.seom.accountbook.ui.screen.setting.category.CategoryUiState
-import com.seom.accountbook.ui.screen.setting.category.SettingBody
+import com.seom.accountbook.ui.components.BackButtonAppBar
+import com.seom.accountbook.ui.components.container.BottomButtonBox
+import com.seom.accountbook.ui.components.text.CustomTextField
 import com.seom.accountbook.ui.theme.ColorPalette
 
 @Composable
@@ -35,8 +26,7 @@ fun MethodAddScreen(
                 MethodUiState.Success.AddMethod -> {
                     onBackButtonPressed()
                 }
-                MethodUiState.Success.FetchMethod -> {
-                }
+                MethodUiState.Success.FetchMethod -> {}
                 is MethodUiState.Error -> {
                     println("Error Method")
                 }
@@ -45,7 +35,9 @@ fun MethodAddScreen(
     }
     MethodBody(
         isModifyMode = methodId.isNullOrBlank().not(),
-        viewModel = viewModel,
+        value = viewModel.name.collectAsState().value,
+        onChangeValue = viewModel::setName,
+        onClickAddBtn = viewModel::addCategory,
         onBackButtonPressed = onBackButtonPressed
     )
 }
@@ -53,107 +45,37 @@ fun MethodAddScreen(
 @Composable
 fun MethodBody(
     isModifyMode: Boolean,
-    viewModel: MethodViewModel,
+    value: String,
+    onChangeValue: (String) -> Unit,
+    onClickAddBtn: () -> Unit,
     onBackButtonPressed: () -> Unit
 ) {
     val modeTitle = if (isModifyMode) "수정하기" else "추가하기"
-    var name = viewModel.name.collectAsState()
 
     Scaffold(topBar = {
-        OneButtonAppBar(title = "결제 수단 $modeTitle") {
-            Image(
-                painter = painterResource(id = R.drawable.ic_back),
-                contentDescription = null,
-                modifier = Modifier.clickable { onBackButtonPressed() })
-        }
+        BackButtonAppBar(
+            title = "결제 수단 $modeTitle",
+            onClickBackBtn = onBackButtonPressed
+        )
     }) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Divider(
-                color = ColorPalette.Purple,
-                thickness = 1.dp
-            )
-            InputField(title = "이름") {
-                Input(content = name.value, onValueChange = viewModel::setName)
-            }
-            Button(
-                onClick = viewModel::addCategory,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 40.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = ColorPalette.Yellow,
-                    disabledBackgroundColor = ColorPalette.Yellow50
-                ),
-                enabled = name.value.isBlank().not()
-            ) {
-                Text(
-                    text = "등록하기",
-                    style = MaterialTheme.typography.caption.copy(
-                        fontWeight = FontWeight(700),
-                        color = ColorPalette.White
-                    ),
-                    modifier = Modifier
-                        .padding(top = 8.dp, bottom = 8.dp)
-                        .background(Color.Transparent),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun InputField(
-    title: String,
-    input: @Composable () -> Unit
-) {
-    Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 16.dp)) {
-        Row(
-            modifier = Modifier
-                .padding(
-                    top = 8.dp,
-                    bottom = 8.dp
-                )
+        BottomButtonBox(
+            onClickBtn = onClickAddBtn,
+            enabled = value.isBlank().not(),
+            buttonText = "등록하기",
+            buttonColor = ColorPalette.Yellow,
+            disabledColor = ColorPalette.Yellow50,
+            modifier = Modifier.fillMaxSize()
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.caption,
-                fontWeight = FontWeight(500),
-                color = ColorPalette.Purple,
-                modifier = Modifier.weight(2f)
-            )
-            Surface(
-                modifier = Modifier
-                    .weight(8f)
-                    .padding(start = 8.dp),
-                color = Color.Transparent
-            ) {
-                input()
-            }
-        }
-        Divider(
-            color = ColorPalette.Purple40,
-            thickness = 1.dp
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-    }
-}
-
-@Composable
-fun Input(
-    content: String,
-    onValueChange: (String) -> Unit
-) {
-    Box() {
-        BasicTextField(
-            value = content,
-            onValueChange = { onValueChange(it) },
-            textStyle = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple),
-        )
-        if (content.isBlank()) {
-            Text(
-                text = "입력하세요.",
-                style = MaterialTheme.typography.caption.copy(color = ColorPalette.LightPurple)
+            CustomTextField(
+                name = "이름",
+                value = value,
+                textColor = ColorPalette.Purple,
+                onValueChanged = onChangeValue,
+                modifier = Modifier.padding(
+                    start = 20.dp,
+                    end = 20.dp,
+                    top = 16.dp
+                )
             )
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.ui.components.BackButtonAppBar
+import com.seom.accountbook.ui.components.common.BaseSnackBar
 import com.seom.accountbook.ui.components.container.BottomButtonBox
 import com.seom.accountbook.ui.components.text.CustomTextField
 import com.seom.accountbook.ui.theme.ColorPalette
+import kotlinx.coroutines.launch
 
 @Composable
 fun MethodAddScreen(
@@ -16,6 +18,7 @@ fun MethodAddScreen(
     viewModel: MethodViewModel,
     onBackButtonPressed: () -> Unit
 ) {
+    val scaffoldState = rememberScaffoldState()
     LaunchedEffect(key1 = Unit) {
         viewModel.methodUiState.collect {
             when (it) {
@@ -30,11 +33,19 @@ fun MethodAddScreen(
                 is MethodUiState.Error -> {
                     println("Error Method")
                 }
+                is MethodUiState.Duplicate -> {
+                    this.launch {
+                        scaffoldState.snackbarHostState.showSnackbar(
+                            message = it.duplicateMsg
+                        )
+                    }
+                }
             }
         }
     }
     MethodBody(
         isModifyMode = methodId.isNullOrBlank().not(),
+        scaffoldState = scaffoldState,
         value = viewModel.name.collectAsState().value,
         onChangeValue = viewModel::setName,
         onClickAddBtn = viewModel::addCategory,
@@ -45,6 +56,7 @@ fun MethodAddScreen(
 @Composable
 fun MethodBody(
     isModifyMode: Boolean,
+    scaffoldState: ScaffoldState,
     value: String,
     onChangeValue: (String) -> Unit,
     onClickAddBtn: () -> Unit,
@@ -52,12 +64,15 @@ fun MethodBody(
 ) {
     val modeTitle = if (isModifyMode) "수정하기" else "추가하기"
 
-    Scaffold(topBar = {
-        BackButtonAppBar(
-            title = "결제 수단 $modeTitle",
-            onClickBackBtn = onBackButtonPressed
-        )
-    }) {
+    Scaffold(
+        topBar = {
+            BackButtonAppBar(
+                title = "결제 수단 $modeTitle",
+                onClickBackBtn = onBackButtonPressed
+            )
+        },
+        snackbarHost = { it.BaseSnackBar(hostState = scaffoldState.snackbarHostState) }
+    ) {
         BottomButtonBox(
             onClickBtn = onClickAddBtn,
             enabled = value.isBlank().not(),

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
@@ -37,7 +37,7 @@ class MethodViewModel(
             when (val result = methodRepository.getMethod(methodId)) {
                 is Result.Error -> _methodUiState.value =
                     MethodUiState.Error(R.string.error_method_get)
-                is Result.Success -> {
+                is Result.Success.Finish -> {
                     val method = result.data
                     currentMethodId = method.id
                     _name.value = method.name

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
@@ -62,7 +62,10 @@ class MethodViewModel(
         when (result) {
             is Result.Error -> _methodUiState.value =
                 MethodUiState.Error(R.string.error_method_add)
-            is Result.Success -> _methodUiState.value = MethodUiState.Success.AddMethod
+            is Result.Success.Finish -> _methodUiState.value = MethodUiState.Success.AddMethod
+            Result.Success.Pause -> _methodUiState.value =
+                MethodUiState.Duplicate("동일한 이름의 결제 수단이 이미 있어요.")
+
         }
     }
 }
@@ -74,6 +77,10 @@ sealed interface MethodUiState {
         object AddMethod : Success
         object FetchMethod : Success
     }
+
+    data class Duplicate(
+        val duplicateMsg: String
+    ) : MethodUiState
 
     data class Error(
         @StringRes

--- a/app/src/main/java/com/seom/accountbook/ui/theme/Color.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/theme/Color.kt
@@ -14,4 +14,6 @@ object ColorPalette {
     val OffWhite = Color(0xFFF7F6F3)
     val Background = Color(0xFFBEBEBE)
     val Green = Color(0xFF4EAABA)
+    
+    val SnackBar = Color(0xFF292929)
 }

--- a/app/src/main/java/com/seom/accountbook/ui/theme/Type.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/theme/Type.kt
@@ -8,43 +8,25 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
 val Typography = Typography(
     body1 = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight(500),
         fontSize = 18.sp
     ),
     body2 = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight(500),
         fontSize = 16.sp,
     ),
     subtitle1 = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight(500),
-        fontSize = 12.sp,
+        fontSize = 14.sp,
     ),
     subtitle2 = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight(700),
-        fontSize = 10.sp
+        fontSize = 12.sp
     ),
     caption = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight(700),
-        fontSize = 14.sp
+        fontSize = 10.sp
     )
-    /* Other default text styles to override
-    button = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.W500,
-        fontSize = 14.sp
-    ),
-    caption = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp
-    )
-    */
 )

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -5,7 +5,6 @@ import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavArgument
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -17,7 +16,6 @@ import com.seom.accountbook.ui.screen.detail.DetailScreen
 import com.seom.accountbook.ui.screen.graph.GraphScreen
 import com.seom.accountbook.ui.screen.history.HistoryScreen
 import com.seom.accountbook.ui.screen.post.PostScreen
-import com.seom.accountbook.ui.screen.post.PostViewModel
 import com.seom.accountbook.ui.screen.setting.SettingScreen
 import com.seom.accountbook.ui.screen.setting.category.CategoryAddScreen
 import com.seom.accountbook.ui.screen.setting.method.MethodAddScreen
@@ -108,7 +106,7 @@ fun AccountNavigationHost(
         }
         // 결제 수단 새로 추가
         composable(
-            route = Method.route
+            route = MethodDestination.route
         ) {
             MethodAddScreen(
                 viewModel = viewModel()
@@ -118,10 +116,10 @@ fun AccountNavigationHost(
         }
         // 결제 수단 변경
         composable(
-            route = Method.routeWithArgs,
-            arguments = Method.arguments
+            route = MethodDestination.routeWithArgs,
+            arguments = MethodDestination.arguments
         ) { navBackStackEntry ->
-            val methodId = navBackStackEntry.arguments?.getString(Method.methodIdArgs)
+            val methodId = navBackStackEntry.arguments?.getString(MethodDestination.methodIdArgs)
             MethodAddScreen(
                 methodId = methodId,
                 viewModel = viewModel()
@@ -131,10 +129,10 @@ fun AccountNavigationHost(
         }
         // 카테고리 새로 추가
         composable(
-            route = Category.routeWithArgs,
-            arguments = Category.arguments
+            route = CategoryDestination.routeWithArgs,
+            arguments = CategoryDestination.arguments
         ) { navBackStackEntry ->
-            val categoryType = navBackStackEntry.arguments?.getString(Category.categoryTypeArgs)
+            val categoryType = navBackStackEntry.arguments?.getString(CategoryDestination.categoryTypeArgs)
             CategoryAddScreen(
                 null,
                 HistoryType.getHistoryType(categoryType?.toInt() ?: 0),
@@ -145,11 +143,11 @@ fun AccountNavigationHost(
         }
         // 카테고리 변경
         composable(
-            route = Category.routeWithAllArgs,
-            arguments = Category.allArguments
+            route = CategoryDestination.routeWithAllArgs,
+            arguments = CategoryDestination.allArguments
         ) { navBackStackEntry ->
-            val categoryId = navBackStackEntry.arguments?.getString(Category.categoryIdArgs)
-            val categoryType = navBackStackEntry.arguments?.getString(Category.categoryTypeArgs)
+            val categoryId = navBackStackEntry.arguments?.getString(CategoryDestination.categoryIdArgs)
+            val categoryType = navBackStackEntry.arguments?.getString(CategoryDestination.categoryTypeArgs)
             CategoryAddScreen(
                 categoryId,
                 HistoryType.getHistoryType(categoryType?.toInt() ?: 0),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <!-- category -->
     <string name="error_category_add">카테고리를 추가하는 도중 문제가 발생했어요.</string>
     <string name="error_category_get">카테고리 정보를 가져오는 도중 문제가 발생했어요.</string>
+    <string name="duplicate_category">동일한 이름의 카테고리가 이미 있습니다.ð</string>
 
     <!-- setting -->
     <string name="error_setting_method_get">결제수단 정보를 가져오는 도중 문제가 발생하였습니다.</string>
@@ -22,5 +23,6 @@
     <!-- method -->
     <string name="error_method_add">결제 수단 정보를 추가하는 도중 문제가 발생했어요.</string>
     <string name="error_method_get">결제 수단 정보를 가져오는 도중 문제가 발생했어요.</string>
+    <string name="duplicate_method">동일한 이름의 결제수단이 이미 있습니다.ð</string>
 
 </resources>


### PR DESCRIPTION
### 📌 Summary
Setting화면과 결제수단, 수입/지출 카테고리 작성화면 Component 분리 및 세부 기능 추가 구현하기

### 🍿 Main Changes 
- [x] 결제 수단 입력 화면 Component 분리하기
- [x] 수입/지출 카테고리 입력화면 Component 분리하기
- [x] 설정 화면 Component 분리하기
- [x] 결제 수단 입력 시, 이름 중복 체크
- [x] 수입/지출 입력 시, 이름 중복 체크
- [x] 이름이 중복일 시 snackbar로 알려주기
- [x] 결제수단, 수입/지출 입력 시, soft keyboard에 의해 버튼이 가려지는거 수정

### 🔥 UseCase
1. 결제수단, 수입/지출 카테고리 추가 시 중복 체크
2. 결제수단, 수입/지출 카테고리 입력 시, sort keyboard 반응형 화면 추가

### 🛠 Related Issue
Closes #35