### PR TITLE
Graph 화면 및 Detail 화면의 Component 정리 및 세부 사항 구현 완료하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/AccountActivity.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.seom.accountbook.ui.components.AccountTabRow
@@ -38,13 +39,13 @@ class AccountActivity : ComponentActivity() {
 @Composable
 fun AccountApp() {
     val navController = rememberNavController()
+    val viewModel: AccountViewModel = viewModel()
 
     val currentBackStack by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStack?.destination
     val currentScreen =
         allScreens.find { currentDestination?.route?.startsWith(it.route) ?: false } ?: History
 
-    println(currentDestination?.route)
     AccountBookTheme() {
         Scaffold(
             bottomBar = {
@@ -58,6 +59,7 @@ fun AccountApp() {
             }
         ) { innerPadding ->
             AccountNavigationHost(
+                viewModel = viewModel,
                 navController = navController,
                 modifier = Modifier.padding(innerPadding)
             )

--- a/app/src/main/java/com/seom/accountbook/AccountDestination.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountDestination.kt
@@ -43,7 +43,7 @@ object Graph : AccountDestination {
     override val group = "graph"
 }
 
-object Detail : AccountDestination {
+object DetailDestination : AccountDestination {
     override val icon = R.drawable.ic_graph
     override val route = "detail"
     override val title = "상세"
@@ -51,7 +51,7 @@ object Detail : AccountDestination {
     const val categoryIdArgs = "category_id"
     const val yearArgs = "year"
     const val monthArgs = "month"
-    val routeWithArgs = "${route}/{${categoryIdArgs}},{${yearArgs}},{${monthArgs}}"
+    val routeWithArgs = "${route}/{${categoryIdArgs}}/{${yearArgs}}/{${monthArgs}}"
     val arguments = listOf(
         navArgument(categoryIdArgs) { type = NavType.StringType },
         navArgument(yearArgs) { type = NavType.IntType },
@@ -98,5 +98,5 @@ object CategoryDestination : AccountDestination {
     )
 }
 
-val allScreens = listOf(History, Post, Calendar, Graph, Detail, Setting, MethodDestination, CategoryDestination)
+val allScreens = listOf(History, Post, Calendar, Graph, DetailDestination, Setting, MethodDestination, CategoryDestination)
 val accountBottomTabScreens = listOf(History, Calendar, Graph, Setting)

--- a/app/src/main/java/com/seom/accountbook/AccountViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountViewModel.kt
@@ -1,0 +1,36 @@
+package com.seom.accountbook
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.time.LocalDate
+
+@RequiresApi(Build.VERSION_CODES.O)
+class AccountViewModel : ViewModel() {
+
+    private val _year = MutableStateFlow(0)
+    val year = _year.asStateFlow()
+    fun setYear(newYear: Int) {
+        _year.value = newYear
+    }
+
+    private val _month = MutableStateFlow(0)
+    val month = _month.asStateFlow()
+    fun setMonth(newMonth: Int) {
+        _month.value = newMonth
+    }
+
+    init {
+        val current = LocalDate.now()
+
+        _year.value = current.year
+        _month.value = current.month.value
+    }
+
+    fun setDate(newYear: Int, newMonth: Int) {
+        _year.value = newYear
+        _month.value = newMonth
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -213,8 +213,7 @@ class AccountDao(
         val db = appDatabase.readable
 
         val minYear = if (month < 6) year - 1 else year
-        val minMonth = if (month < 6) month else month - 5
-        val maxMonth = if (month < 6) 7 + month else month
+        val minMonth = if (month < 6) 7 + month else month - 5
 
         val query = "SELECT " +
                 "A.${AccountEntity.COLUMN_NAME_ID}," +
@@ -233,8 +232,9 @@ class AccountDao(
                 "LEFT JOIN ${CategoryDao.TABLE_NAME} C " +
                 "ON A.${AccountEntity.COLUMN_NAME_CATEGORY} = C.${CategoryEntity.COLUMN_NAME_ID} " +
                 "WHERE ${AccountEntity.COLUMN_NAME_YEAR} BETWEEN $minYear AND $year " +
-                "AND ${AccountEntity.COLUMN_NAME_MONTH} BETWEEN $minMonth AND $maxMonth " +
-                "AND ${AccountEntity.COLUMN_NAME_CATEGORY} = $categoryId "
+                "AND (${AccountEntity.COLUMN_NAME_MONTH} >= $minMonth OR ${AccountEntity.COLUMN_NAME_MONTH} <= $month) " +
+                "AND ${AccountEntity.COLUMN_NAME_CATEGORY} = $categoryId " +
+                "ORDER BY ${AccountEntity.COLUMN_NAME_YEAR} DESC, ${AccountEntity.COLUMN_NAME_MONTH} DESC, ${AccountEntity.COLUMN_NAME_DATE} DESC"
 
         val cursor = db.rawQuery(query, null)
 
@@ -265,8 +265,7 @@ class AccountDao(
         val db = appDatabase.readable
 
         val minYear = if (month < 6) year - 1 else year
-        val minMonth = if (month < 6) month else month - 5
-        val maxMonth = if (month < 6) 7 + month else month
+        val minMonth = if (month < 6) 7 + month else month - 5
 
         val query = "" +
                 "SELECT " +
@@ -274,7 +273,7 @@ class AccountDao(
                 "${AccountEntity.COLUMN_NAME_MONTH} " +
                 "FROM $TABLE_NAME " +
                 "WHERE ${AccountEntity.COLUMN_NAME_YEAR} BETWEEN $minYear AND $year " +
-                "AND ${AccountEntity.COLUMN_NAME_MONTH} BETWEEN $minMonth AND $maxMonth " +
+                "AND (${AccountEntity.COLUMN_NAME_MONTH} >= $minMonth OR ${AccountEntity.COLUMN_NAME_MONTH} <= $month) " +
                 "AND ${AccountEntity.COLUMN_NAME_CATEGORY} = $categoryId " +
                 "GROUP BY ${AccountEntity.COLUMN_NAME_MONTH} " +
                 "ORDER BY ${AccountEntity.COLUMN_NAME_YEAR}, ${AccountEntity.COLUMN_NAME_MONTH}"

--- a/app/src/main/java/com/seom/accountbook/model/history/HistoryType.kt
+++ b/app/src/main/java/com/seom/accountbook/model/history/HistoryType.kt
@@ -1,21 +1,30 @@
 package com.seom.accountbook.model.history
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import com.seom.accountbook.R
 import com.seom.accountbook.model.category.incomeColor
 import com.seom.accountbook.model.category.outcomeColor
+import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.toMoney
 
 enum class HistoryType(
     val type: Int, // 0: Income, 1: Outcome
     @StringRes
     val title: Int,
+    val color: Color,
     val colorList: List<Long>
 ) {
-    INCOME(0, R.string.type_history_income, incomeColor),
-    OUTCOME(1, R.string.type_history_outcome, outcomeColor);
+    INCOME(0, R.string.type_history_income, ColorPalette.Green, incomeColor),
+    OUTCOME(1, R.string.type_history_outcome, ColorPalette.Red, outcomeColor);
 
     companion object {
         fun getHistoryType(typeId: Int) = values().find { it.type == typeId } ?: INCOME
+
+        fun HistoryType.getCountOnType(count: Long): Long {
+            if (this == INCOME) return count
+            else return -count
+        }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -35,6 +35,8 @@ import java.util.*
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun DateAppBar(
+    year: Int,
+    month: Int,
     onDateChange: (LocalDate) -> Unit, // 선택된 날짜 변경 이벤트
     children: @Composable () -> Unit,
     header: (@Composable () -> Unit)? = null,
@@ -43,13 +45,8 @@ fun DateAppBar(
     val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
 
-    val current = LocalDate.now()
-
-    val year = current.year
-    val month = current.month.value
-
-    val maxYear = year
-    val maxMonth = month
+    val maxYear = LocalDate.now().year
+    val maxMonth = LocalDate.now().month.value
     val minYear = year - 30
 
     val date = remember { mutableStateOf(Date(year, month)) }

--- a/app/src/main/java/com/seom/accountbook/ui/components/common/SideItemRow.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/common/SideItemRow.kt
@@ -1,0 +1,28 @@
+package com.seom.accountbook.ui.components.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * 양쪽에 item 들이 있는 Row
+ */
+@Composable
+fun SideItemRow(
+    left: @Composable () -> Unit,
+    right: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        left()
+        right()
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/graph/CircleGraph.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/graph/CircleGraph.kt
@@ -1,0 +1,71 @@
+package com.seom.accountbook.ui.components.graph
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.model.BaseCount
+
+private const val DividerLengthInDegrees = 0f
+private enum class AnimatedCircleProgress { START, END }
+
+@Composable
+fun CircleGraph(
+    data: List<BaseCount>,
+    totalCount: Long,
+    modifier: Modifier = Modifier
+) {
+    val currentState = remember {
+        MutableTransitionState(AnimatedCircleProgress.START)
+            .apply { targetState = AnimatedCircleProgress.END }
+    }
+    val stroke = with(LocalDensity.current) { Stroke(45.dp.toPx()) }
+    val transition = updateTransition(currentState, label = "")
+    val angleOffset by transition.animateFloat(
+        transitionSpec = {
+            tween(
+                delayMillis = 500,
+                durationMillis = 900,
+                easing = LinearOutSlowInEasing
+            )
+        }, label = ""
+    ) { progress ->
+        if (progress == AnimatedCircleProgress.START) {
+            0f
+        } else {
+            360f
+        }
+    }
+
+    Canvas(modifier) {
+        val innerRadius = (size.minDimension - stroke.width) / 2
+        val halfSize = size / 2.0f
+        val topLeft = Offset(
+            halfSize.width - innerRadius,
+            halfSize.height - innerRadius
+        )
+        val size = Size(innerRadius * 2, innerRadius * 2)
+        var startAngle = -90f
+        data.forEachIndexed { index, rate ->
+            val sweep = (rate.count / totalCount.toFloat()) * angleOffset
+            drawArc(
+                color = Color(if(rate.color == 0L) 0xFF2E2E2E else rate.color),
+                startAngle = startAngle + DividerLengthInDegrees,
+                sweepAngle = sweep - DividerLengthInDegrees,
+                topLeft = topLeft,
+                size = size,
+                useCenter = false,
+                style = stroke
+            )
+            startAngle += sweep
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/graph/LinearGraph.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/graph/LinearGraph.kt
@@ -1,0 +1,107 @@
+package com.seom.accountbook.ui.components.graph
+
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.seom.accountbook.model.graph.OutComeByMonth
+
+@Composable
+fun LinearGraph(
+    data: List<OutComeByMonth>,
+    keys: List<String>,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color, // 배경 색
+    lineColor: Brush, // 선 색
+    primaryTextColor: Color, // 강조 글자 색
+    secondaryTextColor: Color, // 일반 글자 색
+    blockNum: Int = 6
+) {
+    val usedData = keys.map { name -> data.find { it.name == name }?.count ?: 0  }
+    Column(
+        modifier = Modifier
+            .height(130.dp)
+            .background(backgroundColor)
+            .padding(7.dp)
+    ) {
+        if (data.isNotEmpty()) {
+            Canvas(
+                modifier
+                    .weight(1f)
+                    .padding(top = 20.dp, bottom = 20.dp)
+            ) {
+                val canvasWidth = size.width
+                val canvasHeight = size.height
+
+                val minValue = usedData.minOf { it }
+                val maxValue = usedData.maxOf { it }
+                val diff = (maxValue - minValue)
+
+                val blockWidth = canvasWidth / (blockNum * 2)
+                val pointX = (0..5).map { index -> (blockWidth) * (index * 2 + 1) }
+                val pointY = usedData.map { canvasHeight - (it - minValue) / (diff / canvasHeight) }
+
+                for (index in 1 until usedData.size) {
+                    val start = Offset(x = pointX[index], y = pointY[index])
+                    val end = Offset(x = pointX[index - 1], y = pointY[index - 1])
+                    drawLine(
+                        start = start,
+                        end = end,
+                        brush = lineColor,
+                        strokeWidth = (2.0).toFloat().dp.toPx()
+                    )
+                }
+
+                keys.forEachIndexed { index, name  ->
+                    drawIntoCanvas {
+                        val count = data.find { it.name == name }?.count ?: 0
+                        it.nativeCanvas.drawText(
+                            count.toString(),
+                            pointX[index],
+                            pointY[index] - (8.sp).toPx(),
+                            Paint().apply {
+                                textSize = (10.sp).toPx()
+                                color =
+                                    (if (index == keys.size - 1) primaryTextColor else secondaryTextColor).toArgb()
+                                typeface =
+                                    Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                                textAlign = Paint.Align.CENTER
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            keys.forEachIndexed { index, row ->
+                Text(
+                    text = row,
+                    style = MaterialTheme.typography.subtitle1.copy(
+                        fontWeight = FontWeight(700),
+                        color = if (index == keys.size - 1) primaryTextColor else secondaryTextColor
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/header/BaseTextHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/header/BaseTextHeader.kt
@@ -1,0 +1,35 @@
+package com.seom.accountbook.ui.components.header
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
+
+@Composable
+fun BaseTextHeader(
+    child: @Composable RowScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(ColorPalette.OffWhite)
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 8.dp,
+                bottom = 8.dp
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            child()
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/header/SigleTextHeader.kt
@@ -20,23 +20,12 @@ import com.seom.accountbook.ui.theme.ColorPalette
 fun SingleTextHeader(
     title: String
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(ColorPalette.OffWhite)
-            .padding(
-                start = 16.dp,
-                end = 16.dp,
-                top = 16.dp
-            )
-    ) {
+    BaseTextHeader {
         CustomText(
             text = title,
             style = MaterialTheme.typography.body2,
             bold = false,
-            color = ColorPalette.LightPurple,
-            modifier = Modifier
-                .padding(top = 8.dp, bottom = 8.dp)
+            color = ColorPalette.LightPurple
         )
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryList.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryList.kt
@@ -1,9 +1,72 @@
 package com.seom.accountbook.ui.components.history
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.seom.accountbook.model.history.HistoryModel
+import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.ui.components.common.BottomSpacer
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.fullFormat
 import java.time.LocalDate
 
 /**
  * 수입/지출 일별 내역을 보여주는 리스트 component
  */
+@RequiresApi(Build.VERSION_CODES.O)
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HistoryList(
+    modifier: Modifier = Modifier,
+    historyGroupedByDate: Map<LocalDate, List<HistoryModel>>,
+    selectedItem: MutableList<Long> = mutableListOf(),
+    onClickItem: (Long) -> Unit = {},
+    onLongClickItem: (Long) -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        if (historyGroupedByDate.isEmpty()) {
+            CustomText(
+                text = "내역이 없습니다.",
+                style = MaterialTheme.typography.subtitle2,
+                color = ColorPalette.Purple,
+                bold = true
+            )
+        } else {
+            LazyColumn {
+                historyGroupedByDate.forEach { (date, histories) ->
+                    stickyHeader {
+                        HistoryListHeader(
+                            date = date.fullFormat(),
+                            income = histories.filter { it.type == HistoryType.INCOME }
+                                .sumOf { it.money },
+                            outCome = histories.filter { it.type == HistoryType.OUTCOME }
+                                .sumOf { it.money }
+                        )
+                    }
+                    items(items = histories) { history ->
+                        HistoryListItem(
+                            history = history,
+                            selected = history.id in selectedItem,
+                            modifier = Modifier
+                                .combinedClickable(
+                                    onClick = { onClickItem(history.id) },
+                                    onLongClick = { onLongClickItem(history.id) }
+                                )
+                        )
+                    }
+                    BottomSpacer(16)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryList.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryList.kt
@@ -1,0 +1,9 @@
+package com.seom.accountbook.ui.components.history
+
+import androidx.compose.runtime.Composable
+import com.seom.accountbook.model.history.HistoryModel
+import java.time.LocalDate
+
+/**
+ * 수입/지출 일별 내역을 보여주는 리스트 component
+ */

--- a/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryListHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryListHeader.kt
@@ -1,0 +1,47 @@
+package com.seom.accountbook.ui.components.history
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.header.BaseTextHeader
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.toMoney
+
+@Composable
+fun HistoryListHeader(
+    date: String,
+    income: Int,
+    outCome: Int
+) {
+    BaseTextHeader {
+        CustomText(
+            text = date,
+            style = MaterialTheme.typography.body2,
+            bold = false,
+            color = ColorPalette.LightPurple
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        if (income > 0) {
+            CountItem(title = "수입", count = income)
+        }
+        Spacer(modifier = Modifier.width(2.dp))
+        if (outCome > 0) {
+            CountItem(title = "지출", count = outCome)
+        }
+    }
+}
+
+@Composable
+fun CountItem(
+    title: String,
+    count: Int
+) {
+    CustomText(
+        text = "$title ${count.toMoney()}원",
+        style = MaterialTheme.typography.caption,
+        color = ColorPalette.LightPurple
+    )
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryListItem.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/history/HistoryListItem.kt
@@ -1,0 +1,91 @@
+package com.seom.accountbook.ui.components.history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.model.history.HistoryModel
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.image.IconImage
+import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.R
+import com.seom.accountbook.model.history.HistoryType.Companion.getCountOnType
+import com.seom.accountbook.ui.components.common.Chip
+import com.seom.accountbook.ui.components.common.SideItemRow
+import com.seom.accountbook.ui.components.text.CustomText
+import com.seom.accountbook.util.ext.toMoney
+
+@Composable
+fun HistoryListItem(
+    history: HistoryModel,
+    selected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(if (selected) ColorPalette.White else Color.Transparent)
+            .padding(
+                start = 16.dp,
+                end = 16.dp
+            )
+    ) {
+        BaseDivider(color = ColorPalette.Purple40)
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (selected) {
+                IconImage(
+                    icon = R.drawable.ic_checkbox_checked,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+            Column {
+                SideItemRow(
+                    left = {
+                        history.categoryName?.let {
+                            Chip(
+                                text = history.categoryName,
+                                color = Color(history.categoryColor!!)
+                            )
+                        }
+                    },
+                    right = {
+                        history.method?.let {
+                            CustomText(
+                                text = history.method,
+                                style = MaterialTheme.typography.caption,
+                                color = ColorPalette.Purple,
+                                align = TextAlign.End
+                            )
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                SideItemRow(
+                    left = {
+                        CustomText(
+                            text = history.content,
+                            style = MaterialTheme.typography.subtitle1,
+                            color = ColorPalette.Purple
+                        )
+                    },
+                    right = {
+                        CustomText(
+                            text = history.type.getCountOnType(history.money.toLong()).toMoney(),
+                            style = MaterialTheme.typography.body2,
+                            color = history.type.color
+                        )
+                    }
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/image/IconImage.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/image/IconImage.kt
@@ -2,7 +2,9 @@ package com.seom.accountbook.ui.components.image
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
@@ -14,11 +16,13 @@ import androidx.compose.ui.res.painterResource
 fun IconImage(
     @DrawableRes
     icon: Int,
-    color: Color
+    color: Color = MaterialTheme.colors.primary,
+    modifier: Modifier = Modifier
 ) {
     Image(
         painter = painterResource(id = icon),
         contentDescription = null,
-        colorFilter = ColorFilter.tint(color)
+        colorFilter = ColorFilter.tint(color),
+        modifier = modifier
     )
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/text/CustomText.kt
@@ -18,7 +18,7 @@ fun CustomText(
     modifier: Modifier = Modifier,
     text: String,
     style: TextStyle,
-    bold: Boolean,
+    bold: Boolean = false,
     color: Color,
     align: TextAlign = TextAlign.Start,
     paddingVertical: Int = 0,

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
@@ -67,6 +67,8 @@ fun CalendarScreen(
     val outcome = histories.filter { it.type == HistoryType.OUTCOME.type }.sumOf { it.count }
 
     DateAppBar(
+        year = 1,
+        month = 31,
         onDateChange = {
             // TODO 변경된 날짜에 맞는 데이터 요청
             viewModel.fetchData(it.year, it.month.value)

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.seom.accountbook.ui.screen.detail
 
 import android.graphics.Paint
@@ -29,7 +31,10 @@ import com.seom.accountbook.R
 import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
 import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.ui.components.BackButtonAppBar
 import com.seom.accountbook.ui.components.OneButtonAppBar
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.graph.LinearGraph
 import com.seom.accountbook.ui.screen.graph.GraphUiState
 import com.seom.accountbook.ui.screen.history.HistoryListHeader
 import com.seom.accountbook.ui.theme.ColorPalette
@@ -76,20 +81,13 @@ fun DetailBody(
 ) {
     Scaffold(
         topBar = {
-            OneButtonAppBar(title = title) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_back),
-                    contentDescription = null,
-                    modifier = Modifier.clickable { onBackButtonPressed() })
-            }
+            BackButtonAppBar(
+                title = title,
+                onClickBackBtn = onBackButtonPressed
+            )
         }
     ) {
-
         Column {
-            Divider(
-                color = ColorPalette.Purple,
-                thickness = 1.dp
-            )
             LinearGraph(
                 data = outComeByMonth,
                 modifier = Modifier.fillMaxWidth(),
@@ -108,10 +106,7 @@ fun DetailBody(
                     ).toString()
                 }
             )
-            Divider(
-                color = ColorPalette.LightPurple,
-                thickness = 1.dp
-            )
+            BaseDivider(color = ColorPalette.LightPurple)
             Spacer(modifier = Modifier.height(16.dp))
             OutComeList(
                 historyGroupedByDate = accounts.groupBy { LocalDate.of(it.year, it.month, it.date) }
@@ -120,98 +115,9 @@ fun DetailBody(
     }
 }
 
-val blockNum = 6
-val linearGraphPadding = 80f
-
-@Composable
-fun LinearGraph(
-    data: List<OutComeByMonth>,
-    keys: List<String>,
-    modifier: Modifier = Modifier,
-    backgroundColor: Color, // 배경 색
-    lineColor: Brush, // 선 색
-    primaryTextColor: Color, // 강조 글자 색
-    secondaryTextColor: Color // 일반 글자 색
-) {
-    val usedData = keys.map { name -> data.find { it.name == name }?.count ?: 0  }
-    Column(
-        modifier = Modifier
-            .height(130.dp)
-            .background(backgroundColor)
-            .padding(7.dp)
-    ) {
-        if (data.isNotEmpty()) {
-            Canvas(
-                modifier
-                    .weight(1f)
-                    .padding(top = 20.dp, bottom = 20.dp)
-            ) {
-                val canvasWidth = size.width
-                val canvasHeight = size.height
-
-                val minValue = usedData.minOf { it }
-                val maxValue = usedData.maxOf { it }
-                val diff = (maxValue - minValue)
-
-                val blockWidth = canvasWidth / (blockNum * 2)
-                val pointX = (0..5).map { index -> (blockWidth) * (index * 2 + 1) }
-                val pointY = usedData.map { canvasHeight - (it - minValue) / (diff / canvasHeight) }
-
-                for (index in 1 until usedData.size) {
-                    val start = Offset(x = pointX[index], y = pointY[index])
-                    val end = Offset(x = pointX[index - 1], y = pointY[index - 1])
-                    drawLine(
-                        start = start,
-                        end = end,
-                        brush = lineColor,
-                        strokeWidth = (2.0).toFloat().dp.toPx()
-                    )
-                }
-
-                keys.forEachIndexed { index, name  ->
-                    drawIntoCanvas {
-                        val count = data.find { it.name == name }?.count ?: 0
-                        it.nativeCanvas.drawText(
-                            count.toString(),
-                            pointX[index],
-                            pointY[index] - (8.sp).toPx(),
-                            Paint().apply {
-                                textSize = (10.sp).toPx()
-                                color =
-                                    (if (index == keys.size - 1) primaryTextColor else secondaryTextColor).toArgb()
-                                typeface =
-                                    Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
-                                textAlign = Paint.Align.CENTER
-                            }
-                        )
-                    }
-                }
-            }
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceAround,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            keys.forEachIndexed { index, row ->
-                Text(
-                    text = row,
-                    style = MaterialTheme.typography.subtitle1.copy(
-                        fontWeight = FontWeight(700),
-                        color = if (index == keys.size - 1) primaryTextColor else secondaryTextColor
-                    )
-                )
-            }
-        }
-    }
-}
-
 @RequiresApi(Build.VERSION_CODES.O)
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun OutComeList(
-    // TODO Key 를 String 으로 두는게 맞을까...
     historyGroupedByDate: Map<LocalDate, List<HistoryModel>>,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -1,45 +1,20 @@
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.seom.accountbook.ui.screen.detail
 
-import android.graphics.Paint
-import android.graphics.Typeface
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.seom.accountbook.R
 import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
-import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.BackButtonAppBar
-import com.seom.accountbook.ui.components.OneButtonAppBar
 import com.seom.accountbook.ui.components.common.BaseDivider
 import com.seom.accountbook.ui.components.graph.LinearGraph
-import com.seom.accountbook.ui.screen.graph.GraphUiState
-import com.seom.accountbook.ui.screen.history.HistoryListHeader
+import com.seom.accountbook.ui.components.history.HistoryList
 import com.seom.accountbook.ui.theme.ColorPalette
-import com.seom.accountbook.util.ext.fullFormat
-import com.seom.accountbook.util.ext.toMoney
 import java.time.LocalDate
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -51,29 +26,26 @@ fun DetailScreen(
     viewModel: DetailViewModel,
     onBackButtonPressed: () -> Unit
 ) {
-    val observer = viewModel.detailUiState.collectAsState()
-    when (val result = observer.value) {
-        DetailUiState.UnInitialized -> {
-            viewModel.fetchData(categoryId = categoryId.toLong(), year, month)
-        }
-        DetailUiState.Loading -> {}
-        is DetailUiState.SuccessFetch -> {
-            DetailBody(
-                title = result.accounts[0].categoryName ?: "UnKnown",
-                accounts = result.accounts,
-                month = month,
-                outComeByMonth = result.outComeByMonth,
-                onBackButtonPressed = onBackButtonPressed
-            )
-        }
-        is DetailUiState.Error -> {}
+    LaunchedEffect(key1 = Unit) {
+        viewModel.fetchData(categoryId.toLong(), year, month)
+    }
+
+    val accounts = viewModel.history.collectAsState()
+    val outcome = viewModel.outComeOnMonth.collectAsState()
+
+    if (accounts.value.isNotEmpty()) {
+        DetailBody(
+            accounts = accounts.value,
+            month = month,
+            outComeByMonth = outcome.value,
+            onBackButtonPressed = onBackButtonPressed
+        )
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun DetailBody(
-    title: String,
     month: Int,
     accounts: List<HistoryModel>,
     outComeByMonth: List<OutComeByMonth>,
@@ -82,155 +54,42 @@ fun DetailBody(
     Scaffold(
         topBar = {
             BackButtonAppBar(
-                title = title,
+                title = accounts.first().categoryName ?: "UnKnow",
                 onClickBackBtn = onBackButtonPressed
             )
         }
     ) {
         Column {
-            LinearGraph(
-                data = outComeByMonth,
-                modifier = Modifier.fillMaxWidth(),
-                backgroundColor = ColorPalette.White,
-                lineColor = Brush.verticalGradient(
-                    colors = listOf(
-                        ColorPalette.LightPurple,
-                        ColorPalette.Purple
-                    )
-                ),
-                primaryTextColor = ColorPalette.Purple,
-                secondaryTextColor = ColorPalette.LightPurple,
-                keys = (5 downTo 0).map { index ->
-                    (
-                        if (month - index > 0) month - index else 12 + month - index
-                    ).toString()
-                }
-            )
+            OutComeGraph(month = month, outComeByMonth = outComeByMonth)
             BaseDivider(color = ColorPalette.LightPurple)
             Spacer(modifier = Modifier.height(16.dp))
-            OutComeList(
+            HistoryList(
                 historyGroupedByDate = accounts.groupBy { LocalDate.of(it.year, it.month, it.date) }
             )
         }
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun OutComeList(
-    historyGroupedByDate: Map<LocalDate, List<HistoryModel>>,
-    modifier: Modifier = Modifier
+fun OutComeGraph(
+    month: Int,
+    outComeByMonth: List<OutComeByMonth>
 ) {
-    LazyColumn(
-        modifier = modifier
-    ) {
-        historyGroupedByDate.forEach { (date, histories) ->
-            stickyHeader {
-                HistoryListHeader(
-                    date = date.fullFormat(),
-                    income = histories.filter { it.type == HistoryType.INCOME }
-                        .sumOf { it.money },
-                    outCome = histories.filter { it.type == HistoryType.OUTCOME }
-                        .sumOf { it.money }
-                )
-            }
-            items(items = histories) { history ->
-                OutComeListItem(
-                    history = history
-                )
-            }
-            item {
-                Divider(
-                    color = ColorPalette.LightPurple,
-                    thickness = 1.dp
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-        }
-    }
-}
-
-@Composable
-fun OutComeListItem(
-    history: HistoryModel,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(Color.Transparent)
-            .padding(
-                start = 16.dp,
-                end = 16.dp,
-                bottom = 8.dp
+    LinearGraph(
+        data = outComeByMonth,
+        modifier = Modifier.fillMaxWidth(),
+        backgroundColor = ColorPalette.White,
+        lineColor = Brush.verticalGradient(
+            colors = listOf(
+                ColorPalette.LightPurple,
+                ColorPalette.Purple
             )
-    ) {
-        Divider(
-            color = ColorPalette.Purple40,
-            thickness = 1.dp
-        )
-        Row(
-            modifier = Modifier.padding(top = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    if (history.categoryName != null) {
-                        Text(
-                            text = history.categoryName,
-                            modifier = Modifier
-                                .widthIn(56.dp)
-                                .clip(RoundedCornerShape(999.dp))
-                                .background(Color(history.categoryColor!!))
-                                .padding(
-                                    start = 8.dp,
-                                    top = 4.dp,
-                                    bottom = 4.dp,
-                                    end = 8.dp
-                                ),
-                            style = MaterialTheme.typography.subtitle2,
-                            color = ColorPalette.White,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                    history.method?.let {
-                        Text(
-                            text = history.method,
-                            style = MaterialTheme.typography.subtitle1,
-                            color = ColorPalette.Purple,
-                            textAlign = TextAlign.End,
-                            modifier = Modifier
-                                .padding(top = 4.dp)
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = history.content,
-                        style = MaterialTheme.typography.caption,
-                        color = ColorPalette.Purple
-                    )
-                    Text(
-                        text = "${
-                            if (history.type == HistoryType.OUTCOME) -1 * history.money
-                            else history.money
-                        } 원",
-                        style = MaterialTheme.typography.body2,
-                        fontWeight = FontWeight(700),
-                        color = if (history.type == HistoryType.INCOME) ColorPalette.Green else ColorPalette.Red
-                    )
-                }
-            }
+        ),
+        primaryTextColor = ColorPalette.Purple,
+        secondaryTextColor = ColorPalette.LightPurple,
+        keys = (5 downTo 0).map { index ->
+            (if (month - index > 0) month - index else 12 + month - index
+                    ).toString()
         }
-    }
+    )
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
@@ -1,17 +1,12 @@
 package com.seom.accountbook.ui.screen.detail
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.seom.accountbook.R
 import com.seom.accountbook.data.entity.Result
-import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
-import com.seom.accountbook.ui.screen.graph.GraphUiState
 import com.seom.accountbook.usecase.GetDetailOutComeOnCategoryUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
@@ -12,45 +12,29 @@ import com.seom.accountbook.ui.screen.graph.GraphUiState
 import com.seom.accountbook.usecase.GetDetailOutComeOnCategoryUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class DetailViewModel(
     private val getDetailOutComeOnCategory: GetDetailOutComeOnCategoryUseCase = GetDetailOutComeOnCategoryUseCase()
 ): ViewModel() {
-    private val _detailUiState = MutableStateFlow<DetailUiState>(DetailUiState.UnInitialized)
-    val detailUiState: StateFlow<DetailUiState>
-        get() = _detailUiState
+
+    private val _history = MutableStateFlow<List<HistoryModel>>(emptyList())
+    val history = _history.asStateFlow()
+
+    private val _outcomeOnMonth = MutableStateFlow<List<OutComeByMonth>>(emptyList())
+    val outComeOnMonth = _outcomeOnMonth.asStateFlow()
 
     fun fetchData(categoryId: Long, year: Int, month: Int) = viewModelScope.launch {
-        _detailUiState.value = DetailUiState.Loading
         val result = getDetailOutComeOnCategory(categoryId,year,month)
 
-        val outComeByMonth = when(val data = result.outComeOnMonth) {
-            is Result.Success.Finish -> data.data
-            else -> emptyList()
+         when(val data = result.outComeOnMonth) {
+            is Result.Success.Finish -> _outcomeOnMonth.value = data.data
+            else -> _history.value = emptyList()
         }
-        val accounts = when(val data = result.accounts) {
-            is Result.Success.Finish-> data.data
-            else -> emptyList()
+        when(val data = result.accounts) {
+            is Result.Success.Finish-> _history.value = data.data
+            else -> _history.value = emptyList()
         }
-        _detailUiState.value = DetailUiState.SuccessFetch(
-            outComeByMonth = outComeByMonth,
-            accounts = accounts
-        )
     }
-}
-
-sealed interface DetailUiState {
-    object UnInitialized : DetailUiState
-    object Loading : DetailUiState
-
-    data class SuccessFetch(
-        val outComeByMonth: List<OutComeByMonth>,
-        val accounts: List<HistoryModel>
-    ) : DetailUiState
-
-    data class Error(
-        @StringRes
-        val errorMsg: Int
-    ) : DetailUiState
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -2,36 +2,26 @@ package com.seom.accountbook.ui.screen.graph
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.animation.core.*
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.vector.VectorProperty
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.seom.accountbook.Detail
-import com.seom.accountbook.model.BaseCount
+import com.seom.accountbook.DetailDestination
 import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.ui.components.DateAppBar
-import com.seom.accountbook.ui.screen.calendar.CalendarContainer
-import com.seom.accountbook.ui.screen.calendar.RowData
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.common.BottomSpacer
+import com.seom.accountbook.ui.components.common.Chip
+import com.seom.accountbook.ui.components.common.SideItemRow
+import com.seom.accountbook.ui.components.graph.CircleGraph
+import com.seom.accountbook.ui.components.text.CustomText
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.toMoney
 import java.time.LocalDate
@@ -42,153 +32,92 @@ fun GraphScreen(
     viewModel: GraphViewModel,
     onPushNavigate: (String, String) -> Unit
 ) {
-    var accounts by remember { mutableStateOf<List<OutComeByCategory>>(emptyList()) }
+    LaunchedEffect(key1 = Unit) {
+        val current = LocalDate.now()
 
-    val observer = viewModel.graphUiState.collectAsState()
-    when (val result = observer.value) {
-        GraphUiState.UnInitialized -> {
-            val current = LocalDate.now()
-
-            val year = current.year
-            val month = current.month.value
-            viewModel.fetchData(year, month)
-        }
-        GraphUiState.Loading -> {}
-        is GraphUiState.SuccessFetch -> {
-            accounts = result.accounts
-        }
-        is GraphUiState.Error -> {}
+        val year = current.year
+        val month = current.month.value
+        viewModel.fetchData(year, month)
     }
 
-    val totalCount = accounts.sumOf { it.count }
+    val accounts = viewModel.outcome.collectAsState()
+    val totalCount = accounts.value.sumOf { it.count }
 
     DateAppBar(
         onDateChange = {
             viewModel.fetchData(it.year, it.month.value)
         },
         children = {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Divider(
-                    color = ColorPalette.Purple,
-                    thickness = 1.dp
+            GraphBody(totalCount = totalCount, accounts = accounts.value, onClickItem = {
+                onPushNavigate(
+                    DetailDestination.route,
+                    "$it/${viewModel.currentYear}/${viewModel.currentMonth}"
                 )
-                TopRow(totalCount = totalCount)
-                Divider(
-                    color = ColorPalette.LightPurple,
-                    thickness = 1.dp
+            })
+        }
+    )
+}
+
+@Composable
+fun GraphBody(
+    totalCount: Long,
+    accounts: List<OutComeByCategory>,
+    onClickItem: (Long) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        BaseDivider(color = ColorPalette.Purple)
+        TopRow(totalCount = totalCount)
+        BaseDivider(color = ColorPalette.LightPurple)
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (accounts.isEmpty()) {
+                Text(
+                    text = "내역이 없습니다.",
+                    style = MaterialTheme.typography.subtitle1.copy(color = ColorPalette.Purple),
+                    modifier = Modifier.align(Alignment.Center)
                 )
-                Box(modifier = Modifier.fillMaxSize()) {
-                    if (accounts.isNullOrEmpty()) {
-                        Text(
-                            text = "내역이 없습니다.",
-                            style = MaterialTheme.typography.subtitle1.copy(color = ColorPalette.Purple),
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else {
-                        Column() {
-                            Spacer(modifier = Modifier.height(24.dp))
-                            CircleGraphByRate(
-                                date = accounts,
-                                totalCount = totalCount,
-                                modifier = Modifier
-                                    .height(254.dp)
-                                    .fillMaxWidth()
-                            )
-                            Spacer(modifier = Modifier.height(24.dp))
-                            CategoryList(
-                                data = accounts,
-                                totalCount = totalCount,
-                                onItemClick = {
-                                    onPushNavigate(
-                                        Detail.route,
-                                        "$it,${viewModel.currentYear},${viewModel.currentMonth}"
-                                    )
-                                })
-                        }
-                    }
+            } else {
+                Column {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    CircleGraph(
+                        data = accounts,
+                        totalCount = totalCount,
+                        modifier = Modifier
+                            .height(254.dp)
+                            .fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    CategoryList(
+                        data = accounts,
+                        totalCount = totalCount,
+                        onItemClick = onClickItem
+                    )
                 }
             }
         }
-    )
+    }
 }
 
 @Composable
 fun TopRow(
     totalCount: Long
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 16.dp, top = 9.dp, end = 16.dp, bottom = 9.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = "이번 달 총 지출 금액",
-            style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
-        )
-        Text(
-            text = "${totalCount.toMoney()} 원",
-            style = MaterialTheme.typography.caption.copy(color = ColorPalette.Red)
-        )
-    }
-}
-
-private const val DividerLengthInDegrees = 0f
-
-private enum class AnimatedCircleProgress { START, END }
-
-@Composable
-fun CircleGraphByRate(
-    date: List<BaseCount>,
-    totalCount: Long,
-    modifier: Modifier = Modifier
-) {
-    val currentState = remember {
-        MutableTransitionState(AnimatedCircleProgress.START)
-            .apply { targetState = AnimatedCircleProgress.END }
-    }
-    val stroke = with(LocalDensity.current) { Stroke(45.dp.toPx()) }
-    val transition = updateTransition(currentState)
-    val angleOffset by transition.animateFloat(
-        transitionSpec = {
-            tween(
-                delayMillis = 500,
-                durationMillis = 900,
-                easing = LinearOutSlowInEasing
+    SideItemRow(
+        modifier = Modifier.padding(start = 16.dp, top = 9.dp, end = 16.dp, bottom = 9.dp),
+        left = {
+            CustomText(
+                text = "이번 달 총 지출 금액",
+                style = MaterialTheme.typography.subtitle1,
+                color = ColorPalette.Purple
+            )
+        },
+        right = {
+            CustomText(
+                text = totalCount.toMoney(),
+                style = MaterialTheme.typography.caption,
+                color = ColorPalette.Red
             )
         }
-    ) { progress ->
-        if (progress == AnimatedCircleProgress.START) {
-            0f
-        } else {
-            360f
-        }
-    }
-
-    Canvas(modifier) {
-        val innerRadius = (size.minDimension - stroke.width) / 2
-        val halfSize = size / 2.0f
-        val topLeft = Offset(
-            halfSize.width - innerRadius,
-            halfSize.height - innerRadius
-        )
-        val size = Size(innerRadius * 2, innerRadius * 2)
-        var startAngle = -90f
-        date.forEachIndexed { index, rate ->
-            val sweep = (rate.count / totalCount.toFloat()) * angleOffset
-            drawArc(
-                color = Color(if(rate.color == 0L) 0xFF2E2E2E else rate.color),
-                startAngle = startAngle + DividerLengthInDegrees,
-                sweepAngle = sweep - DividerLengthInDegrees,
-                topLeft = topLeft,
-                size = size,
-                useCenter = false,
-                style = stroke
-            )
-            startAngle += sweep
-        }
-    }
+    )
 }
 
 @Composable
@@ -205,13 +134,7 @@ fun CategoryList(
                 totalCount = totalCount,
                 modifier = Modifier.clickable { onItemClick(row.id) })
         }
-        item {
-            Divider(
-                color = ColorPalette.LightPurple,
-                thickness = 1.dp
-            )
-            Spacer(modifier = Modifier.height(40.dp))
-        }
+        BottomSpacer(40)
     }
 }
 
@@ -224,43 +147,30 @@ fun CategoryOutComeItem(
     Column(
         modifier = modifier.padding(start = 16.dp, end = 16.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = data.name,
-                    style = MaterialTheme.typography.subtitle2.copy(
-                        fontWeight = FontWeight(700),
-                        color = ColorPalette.White
-                    ),
-                    modifier = Modifier
-                        .widthIn(56.dp)
-                        .clip(RoundedCornerShape(999.dp))
-                        .background(Color(if (data.color == 0L) 0xFF2E2E2E else data.color))
-                        .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
-                    textAlign = TextAlign.Center
-                )
-                Text(
-                    text = data.count.toMoney(),
-                    style = MaterialTheme.typography.caption.copy(
-                        fontWeight = FontWeight(500),
-                        color = ColorPalette.Purple
-                    ),
-                    modifier = Modifier.padding(start = 8.dp)
+        SideItemRow(
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            left = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Chip(
+                        text = data.name,
+                        color = Color(if (data.color == 0L) 0xFF2E2E2E else data.color)
+                    )
+                    CustomText(
+                        text = data.count.toMoney(),
+                        style = MaterialTheme.typography.subtitle1,
+                        color = ColorPalette.Purple,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+            },
+            right = {
+                CustomText(
+                    text = "${((data.count / totalCount.toFloat()) * 100).toInt()}%",
+                    style = MaterialTheme.typography.subtitle1,
+                    color = ColorPalette.Purple
                 )
             }
-            Text(
-                text = "${((data.count / totalCount.toFloat()) * 100).toInt().toString()}%",
-                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
-            )
-        }
-        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+        )
+        BaseDivider(color = ColorPalette.Purple40)
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
@@ -18,9 +18,6 @@ import kotlinx.coroutines.launch
 class GraphViewModel(
     private val accountRepository: AccountRepository = AccountRepositoryImpl()
 ) : ViewModel() {
-    var currentYear = 0
-    var currentMonth = 0
-
     private val _outcome = MutableStateFlow<List<OutComeByCategory>>(emptyList())
     val outcome = _outcome.asStateFlow()
 
@@ -28,8 +25,6 @@ class GraphViewModel(
         when (val result = accountRepository.getOutComeOnCategory(year, month)) {
             is Result.Error -> {}
             is Result.Success.Finish -> {
-                currentYear = year
-                currentMonth = month
                 _outcome.value = result.data
             }
         }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -50,6 +50,8 @@ fun HistoryScreen(
     var histories = viewModel.histories.collectAsState()
 
     DateAppBar(
+        year = 1,
+        month = 31,
         onDateChange = { date ->
             // TODO 변경된 날짜에 맞는 데이터 요청
             viewModel.fetchData(date.year, date.month.value)

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -33,6 +33,7 @@ import com.seom.accountbook.ui.components.text.CustomText
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.R
 import com.seom.accountbook.ui.components.common.Chip
+import com.seom.accountbook.ui.components.common.SideItemRow
 import com.seom.accountbook.ui.components.image.IconImage
 
 @Composable
@@ -116,6 +117,7 @@ fun LazyListScope.SettingGroup(
     destination: AccountDestination,
     onPushNavigate: (String, String) -> Unit
 ) {
+    BottomSpacer(16)
     stickyHeader { SingleTextHeader(title = itemName) }
     items(items = items) { item ->
         SettingItem(
@@ -134,7 +136,6 @@ fun LazyListScope.SettingGroup(
         ) {
             IconImage(icon = R.drawable.ic_plus, color = ColorPalette.Purple)
         }
-        Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
     }
 }
 
@@ -149,21 +150,19 @@ fun SettingItem(
             .padding(start = 16.dp, end = 10.dp)
     ) {
         BaseDivider(color = ColorPalette.Purple40)
-        Row(
+        SideItemRow(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 12.dp)
                 .clickable { onClickItem() },
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            CustomText(
-                text = itemName,
-                style = MaterialTheme.typography.subtitle1,
-                bold = true,
-                color = ColorPalette.Purple
-            )
-            rightChild()
-        }
+            left = {
+                CustomText(
+                    text = itemName,
+                    style = MaterialTheme.typography.subtitle1,
+                    bold = true,
+                    color = ColorPalette.Purple
+                )
+            },
+            right = rightChild
+        )
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/theme/Type.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/theme/Type.kt
@@ -16,6 +16,7 @@ val Typography = Typography(
     body2 = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontSize = 16.sp,
+        lineHeight = 18.sp
     ),
     subtitle1 = TextStyle(
         fontFamily = FontFamily.SansSerif,

--- a/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
@@ -1,4 +1,4 @@
 package com.seom.accountbook.util.ext
 import java.text.DecimalFormat
 
-fun Long.toMoney(): String = formatter.format(this)
+fun Long.toMoney(): String = "${formatter.format(this)} 원"

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -3,6 +3,7 @@ package com.seom.accountbook.util
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -23,6 +24,7 @@ import com.seom.accountbook.ui.screen.setting.method.MethodAddScreen
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AccountNavigationHost(
+    viewModel: AccountViewModel,
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
@@ -49,6 +51,8 @@ fun AccountNavigationHost(
         }
         composable(route = Graph.route) {
             GraphScreen(
+                mainViewModel = viewModel,
+                onDateChange = viewModel::setDate,
                 viewModel = viewModel(),
                 onPushNavigate = { route, argument ->
                     navController.navigateSingleTop(route, argument)

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -87,12 +87,12 @@ fun AccountNavigationHost(
         }
 
         composable(
-            route = Detail.routeWithArgs,
-            arguments = Detail.arguments
+            route = DetailDestination.routeWithArgs,
+            arguments = DetailDestination.arguments
         ) { navBackStackEntry ->
-            val year = navBackStackEntry.arguments?.getInt(Detail.yearArgs)
-            val month = navBackStackEntry.arguments?.getInt(Detail.monthArgs)
-            val categoryId = navBackStackEntry.arguments?.getString(Detail.categoryIdArgs)
+            val year = navBackStackEntry.arguments?.getInt(DetailDestination.yearArgs)
+            val month = navBackStackEntry.arguments?.getInt(DetailDestination.monthArgs)
+            val categoryId = navBackStackEntry.arguments?.getString(DetailDestination.categoryIdArgs)
 
             if (year != null && month != null && categoryId != null) {
                 DetailScreen(


### PR DESCRIPTION
### 📌 Summary
Graph화면과 Detail 화면의 Component 정리 및 세부적인 구현 사항 완료하기!

### 🍿 Main Changes 
- [x] Detail 화면의 Component 정리하기
- [x] Graph 화면의 Component 정리하기
- [x] Detail 화면에서 이전 화면으로 돌아갈 때 연도/월 유지하기
- [x] 이전 화면으로 돌아오면 유지된 연도/월에 해당하는 데이터 불러오기

### 🔥 UseCase
1. Detail화면에서 이전 화면으로 돌아오면 이전의 Detail 화면의 연도와 월을 유지하고, 해당 연도/월에 맞는 데이터 재호출

### 🛠 Related Issue
Closes #39 