### PR TITLE
달력 화면 Component 정리 및 세부 사항 구현 완료하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/data/entity/calendar/CalendarEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/calendar/CalendarEntity.kt
@@ -2,6 +2,6 @@ package com.seom.accountbook.data.entity.calendar
 
 data class CalendarEntity(
     val date: Int,
-    val count: Int,
+    val count: Long,
     val type: Int
 )

--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -199,7 +199,7 @@ class AccountDao(
                 accounts.add(
                     CalendarEntity(
                         date = cursor.getInt(0),
-                        count = cursor.getInt(1),
+                        count = cursor.getLong(1),
                         type = cursor.getInt(2)
                     )
                 )

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import com.seom.accountbook.R
 import com.seom.accountbook.model.common.Date
+import com.seom.accountbook.ui.components.common.BaseDivider
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.format
 import kotlinx.coroutines.launch
@@ -142,13 +143,13 @@ fun AppBar(
     onPrevDate: () -> Unit,
     onPostDate: () -> Unit
 ) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        color = Color.Transparent
+    Column(
+        modifier = Modifier.background(Color.Transparent)
     ) {
         Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Image(
@@ -166,6 +167,7 @@ fun AppBar(
                 contentDescription = null,
                 modifier = Modifier.clickable { onPostDate() })
         }
+        BaseDivider(color = ColorPalette.Purple)
     }
 }
 

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/CalendarContainer.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/CalendarContainer.kt
@@ -1,0 +1,69 @@
+package com.seom.accountbook.ui.components.calendar
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import com.seom.accountbook.ui.components.calendar.day.DayState
+import com.seom.accountbook.ui.components.calendar.month.DaysOfWeek
+import com.seom.accountbook.ui.components.calendar.month.MonthContent
+import com.seom.accountbook.ui.components.calendar.month.MonthState
+import com.seom.accountbook.ui.components.calendar.week.DefaultWeekHeader
+import com.seom.accountbook.ui.components.calendar.week.rotateRight
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.temporal.WeekFields
+import java.util.*
+
+@Stable
+class CalendarState(
+    val monthState: MonthState
+)
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun CalendarContainer(
+    calendarState: CalendarState,
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek,
+    today: LocalDate = LocalDate.now(),
+    showAdjacentMonths: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState) -> Unit,
+    weekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultWeekHeader(dayOfWeek = it) },
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit = { content ->
+        Box { content(PaddingValues()) }
+    }
+) {
+    val dayOfWeek = remember(firstDayOfWeek) {
+        DayOfWeek.values().rotateRight(DaysOfWeek - firstDayOfWeek.ordinal)
+    }
+
+    Column(modifier = modifier) {
+        MonthContent(
+            showAdjacentMonths = showAdjacentMonths,
+            currentMonth = calendarState.monthState.currentMonth,
+            daysOfWeek = dayOfWeek,
+            today = today,
+            dayContent = dayContent,
+            weekHeader = weekHeader,
+            monthContainer = monthContainer
+        )
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun rememberCalendarState(
+    initialMonth: YearMonth = YearMonth.now(),
+    monthState: MonthState = rememberSaveable(saver = MonthState.Saver()) {
+        MonthState(initialMonth = initialMonth)
+    },
+): CalendarState = remember { CalendarState(monthState) }

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/Day.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/Day.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.day
+package com.seom.accountbook.ui.components.calendar.day
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/DayState.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/DayState.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.day
+package com.seom.accountbook.ui.components.calendar.day
 
 import androidx.compose.runtime.Stable
 

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/DefaultDay.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/DefaultDay.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.day
+package com.seom.accountbook.ui.components.calendar.day
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -7,19 +7,21 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.ui.components.text.CustomText
 import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.dayOfWeekText
 import com.seom.accountbook.util.ext.toMoney
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -27,7 +29,6 @@ import com.seom.accountbook.util.ext.toMoney
 fun DefaultDate(
     account: Map<Int, List<CalendarEntity>>,
     state: DayState,
-    modifier: Modifier = Modifier,
     currentDayColor: Color = ColorPalette.White
 ) {
     val date = state.date
@@ -41,8 +42,7 @@ fun DefaultDate(
             .aspectRatio(1f)
             .heightIn(60.dp),
         border = BorderStroke(1.dp, ColorPalette.Purple40),
-        backgroundColor = if (state.isCurrentDay) currentDayColor else ColorPalette.OffWhite,
-        shape = RectangleShape
+        backgroundColor = if (state.isCurrentDay) currentDayColor else ColorPalette.OffWhite
     ) {
         Box(
             modifier = Modifier.padding(4.dp)
@@ -51,34 +51,32 @@ fun DefaultDate(
                 Column(
                     modifier = Modifier.align(Alignment.TopStart)
                 ) {
-                    Text(
-                        text = income.toMoney(),
-                        fontWeight = FontWeight(500),
-                        color = ColorPalette.Green,
-                        fontSize = 8.sp
-                    )
-                    Text(
-                        text = (-1 * outcome).toMoney(),
-                        fontWeight = FontWeight(500),
-                        color = ColorPalette.Red,
-                        fontSize = 8.sp
-                    )
-                    Text(
-                        text = (income - outcome).toMoney(),
-                        fontWeight = FontWeight(500),
-                        color = ColorPalette.Purple,
-                        fontSize = 8.sp
-                    )
+                    DateCount(count = income, color = HistoryType.INCOME.color)
+                    DateCount(count = (-1 * outcome), color = HistoryType.OUTCOME.color)
+                    DateCount(count = income - outcome, color = ColorPalette.Purple)
                 }
             }
-            Text(
+            CustomText(
                 text = date.dayOfMonth.toString(),
-                style = MaterialTheme.typography.subtitle1.copy(
-                    color = if (state.isFromCurrentMonth) ColorPalette.Purple else ColorPalette.Purple40,
-                    fontWeight = FontWeight(700)
-                ),
+                style = TextStyle(fontSize = 9.sp),
+                color = if (state.isFromCurrentMonth) ColorPalette.Purple else ColorPalette.Purple40,
+                bold = true,
                 modifier = Modifier.align(Alignment.BottomEnd)
             )
         }
+    }
+}
+
+@Composable
+fun DateCount(
+    count: Long,
+    color: Color
+) {
+    if (count != 0L) {
+        CustomText(
+            text = count.toMoney(),
+            style = TextStyle(fontSize = 9.sp),
+            color = color
+        )
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/WeekDay.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/day/WeekDay.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.day
+package com.seom.accountbook.ui.components.calendar.day
 
 import androidx.compose.runtime.Immutable
 import java.time.LocalDate

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/month/MonthContent.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/month/MonthContent.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.month
+package com.seom.accountbook.ui.components.calendar.month
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -6,10 +6,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.seom.accountbook.data.entity.calendar.CalendarEntity
-import com.seom.accountbook.ui.screen.calendar.day.DayState
-import com.seom.accountbook.ui.screen.calendar.week.WeekContent
-import com.seom.accountbook.ui.screen.calendar.week.getWeeks
+import com.seom.accountbook.ui.components.calendar.day.DayState
+import com.seom.accountbook.ui.components.calendar.week.WeekContent
+import com.seom.accountbook.ui.components.calendar.week.getWeeks
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/month/MonthState.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/month/MonthState.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.month
+package com.seom.accountbook.ui.components.calendar.month
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/DefaultWeekHeader.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/DefaultWeekHeader.kt
@@ -1,4 +1,4 @@
-package com.seom.accountbook.ui.screen.calendar.week
+package com.seom.accountbook.ui.components.calendar.week
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/Week.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/Week.kt
@@ -1,7 +1,7 @@
-package com.seom.accountbook.ui.screen.calendar.week
+package com.seom.accountbook.ui.components.calendar.week
 
 import androidx.compose.runtime.Immutable
-import com.seom.accountbook.ui.screen.calendar.day.Day
+import com.seom.accountbook.ui.components.calendar.day.Day
 
 @Immutable
 internal class Week(

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/WeekContent.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/WeekContent.kt
@@ -1,10 +1,9 @@
-package com.seom.accountbook.ui.screen.calendar.week
+package com.seom.accountbook.ui.components.calendar.week
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.seom.accountbook.data.entity.calendar.CalendarEntity
-import com.seom.accountbook.ui.screen.calendar.day.DayState
+import com.seom.accountbook.ui.components.calendar.day.DayState
 
 @Composable
 internal fun WeekContent(

--- a/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/WeekUtil.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/calendar/week/WeekUtil.kt
@@ -1,8 +1,8 @@
-package com.seom.accountbook.ui.screen.calendar.week
+package com.seom.accountbook.ui.components.calendar.week
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import com.seom.accountbook.ui.screen.calendar.day.WeekDay
+import com.seom.accountbook.ui.components.calendar.day.WeekDay
 import com.seom.accountbook.util.daysUntil
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
@@ -7,177 +7,118 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.AccountViewModel
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.DateAppBar
-import com.seom.accountbook.ui.screen.calendar.day.DayState
-import com.seom.accountbook.ui.screen.calendar.day.DefaultDate
-import com.seom.accountbook.ui.screen.calendar.month.DaysOfWeek
-import com.seom.accountbook.ui.screen.calendar.month.MonthContent
-import com.seom.accountbook.ui.screen.calendar.month.MonthState
-import com.seom.accountbook.ui.screen.calendar.week.DefaultWeekHeader
-import com.seom.accountbook.ui.screen.calendar.week.rotateRight
+import com.seom.accountbook.ui.components.calendar.CalendarContainer
+import com.seom.accountbook.ui.components.calendar.CalendarState
+import com.seom.accountbook.ui.components.calendar.rememberCalendarState
+import com.seom.accountbook.ui.components.calendar.day.DefaultDate
+import com.seom.accountbook.ui.components.common.BaseDivider
+import com.seom.accountbook.ui.components.common.SideItemRow
+import com.seom.accountbook.ui.components.text.CustomText
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.toMoney
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.temporal.WeekFields
-import java.util.*
-
-@Stable
-public class CalendarState(
-    public val monthState: MonthState
-)
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun CalendarScreen(
-    viewModel: CalendarViewModel,
-    onPushNavigate: (String, String) -> Unit
+    mainViewModel: AccountViewModel,
+    onDateChange: (Int, Int) -> Unit,
+    viewModel: CalendarViewModel
 ) {
-    var histories by remember { mutableStateOf<List<CalendarEntity>>(emptyList()) }
+    val year = mainViewModel.year.collectAsState()
+    val month = mainViewModel.month.collectAsState()
     val calendarState = rememberCalendarState()
 
-    val observer = viewModel.categoryUiState.collectAsState()
-    when (val result = observer.value) {
-        CalendarUiState.UnInitialized -> {
-            val current = LocalDate.now()
-
-            val year = current.year
-            val month = current.month.value
-            viewModel.fetchData(year, month)
-        }
-        CalendarUiState.Loading -> {}
-        is CalendarUiState.SuccessFetch -> {
-            histories = result.accounts
-        }
-        is CalendarUiState.Error -> {}
+    LaunchedEffect(key1 = year.value, key2 = month.value) {
+        viewModel.fetchData(year.value, month.value)
+        calendarState.monthState.currentMonth =
+            YearMonth.from(LocalDate.of(year.value, month.value, 1))
     }
 
-    val calendarDate = histories.groupBy { it.date }
+    val histories = viewModel.histories.collectAsState()
+    DateAppBar(
+        year = year.value,
+        month = month.value,
+        onDateChange = {
+            onDateChange(it.year, it.month.value)
+        },
+        children = {
+            CalendarBody(
+                calendarState = calendarState,
+                histories = histories.value
+            )
+        }
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun CalendarBody(
+    calendarState: CalendarState,
+    histories: List<CalendarEntity>
+) {
     val income = histories.filter { it.type == HistoryType.INCOME.type }.sumOf { it.count }
     val outcome = histories.filter { it.type == HistoryType.OUTCOME.type }.sumOf { it.count }
 
-    DateAppBar(
-        year = 1,
-        month = 31,
-        onDateChange = {
-            // TODO 변경된 날짜에 맞는 데이터 요청
-            viewModel.fetchData(it.year, it.month.value)
-            calendarState.monthState.currentMonth = YearMonth.from(it)
-        },
-        children = {
-            Column {
-                Divider(
-                    color = ColorPalette.Purple,
-                    thickness = 1.dp
-                )
-                Spacer(modifier = Modifier.height(20.dp))
-                CalendarContainer(
-                    calendarState = calendarState,
-                    dayContent = {
-                        DefaultDate(
-                            account = calendarDate,
-                            state = it
-                        )
-                    }
-                )
-                Spacer(modifier = Modifier.height(5.dp))
-                RowData(title = "수입", data = income, dateColor = ColorPalette.Green)
-                RowData(title = "지출", data = -1 * outcome, dateColor = ColorPalette.Red)
-                RowData(title = "총합", data = income - outcome, dateColor = ColorPalette.Purple)
-                Divider(
-                    color = ColorPalette.LightPurple,
-                    thickness = 1.dp
+    Column {
+        BaseDivider(color = ColorPalette.Purple)
+        Spacer(modifier = Modifier.height(20.dp))
+        CalendarContainer(
+            calendarState = calendarState,
+            dayContent = {
+                DefaultDate(
+                    account = histories.groupBy { it.date },
+                    state = it
                 )
             }
-        })
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Composable
-fun CalendarContainer(
-    calendarState: CalendarState,
-    modifier: Modifier = Modifier,
-    firstDayOfWeek: DayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek,
-    today: LocalDate = LocalDate.now(),
-    showAdjacentMonths: Boolean = true,
-    dayContent: @Composable BoxScope.(DayState) -> Unit,
-    weekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultWeekHeader(dayOfWeek = it) },
-    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit = { content ->
-        Box { content(PaddingValues()) }
-    }
-) {
-    val dayOfWeek = remember(firstDayOfWeek) {
-        DayOfWeek.values().rotateRight(DaysOfWeek - firstDayOfWeek.ordinal)
-    }
-
-    Column(modifier = modifier) {
-        MonthContent(
-            showAdjacentMonths = showAdjacentMonths,
-            currentMonth = calendarState.monthState.currentMonth,
-            daysOfWeek = dayOfWeek,
-            today = today,
-            dayContent = dayContent,
-            weekHeader = weekHeader,
-            monthContainer = monthContainer
         )
+        Spacer(modifier = Modifier.height(5.dp))
+        RowData(title = "수입", data = income, dateColor = ColorPalette.Green)
+        RowData(title = "지출", data = -1 * outcome, dateColor = ColorPalette.Red)
+        RowData(title = "총합", data = income - outcome, dateColor = ColorPalette.Purple)
+        BaseDivider(color = ColorPalette.LightPurple)
     }
 }
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Composable
-fun rememberCalendarState(
-    initialMonth: YearMonth = YearMonth.now(),
-    monthState: MonthState = rememberSaveable(saver = MonthState.Saver()) {
-        MonthState(initialMonth = initialMonth)
-    },
-): CalendarState = remember { CalendarState(monthState) }
 
 @Composable
 fun RowData(
     title: String,
-    data: Int,
+    data: Long,
     dateColor: Color
 ) {
     Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 15.dp,
-                    end = 15.dp,
-                    top = 8.dp,
-                    bottom = 8.dp
-                ),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.caption.copy(
-                    fontWeight = FontWeight(500),
+        SideItemRow(
+            left = {
+                CustomText(
+                    text = title,
+                    style = MaterialTheme.typography.subtitle1,
                     color = ColorPalette.Purple
                 )
-            )
-            Text(
-                text = "${data.toMoney()} 원",
-                style = MaterialTheme.typography.caption.copy(
+            },
+            right = {
+                CustomText(
+                    text = data.toMoney(),
+                    style = MaterialTheme.typography.subtitle1,
                     color = dateColor
                 )
+            },
+            modifier = Modifier.padding(
+                start = 15.dp,
+                top = 8.dp,
+                end = 15.dp,
+                bottom = 8.dp
             )
-        }
-        Divider(
-            color = ColorPalette.Purple40,
-            thickness = 1.dp
         )
+        BaseDivider(color = ColorPalette.Purple40)
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
@@ -3,6 +3,8 @@ package com.seom.accountbook.ui.screen.calendar
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -70,8 +72,11 @@ fun CalendarBody(
     val income = histories.filter { it.type == HistoryType.INCOME.type }.sumOf { it.count }
     val outcome = histories.filter { it.type == HistoryType.OUTCOME.type }.sumOf { it.count }
 
-    Column {
-        BaseDivider(color = ColorPalette.Purple)
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier.verticalScroll(scrollState)
+    ) {
         Spacer(modifier = Modifier.height(20.dp))
         CalendarContainer(
             calendarState = calendarState,

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
@@ -10,36 +10,20 @@ import com.seom.accountbook.data.repository.AccountRepository
 import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class CalendarViewModel(
     private val accountRepository: AccountRepository = AccountRepositoryImpl()
 ) : ViewModel() {
-    private val _categoryUiState = MutableStateFlow<CalendarUiState>(CalendarUiState.UnInitialized)
-    val categoryUiState: StateFlow<CalendarUiState>
-        get() = _categoryUiState
+
+    private val _histories = MutableStateFlow<List<CalendarEntity>>(emptyList())
+    val histories = _histories.asStateFlow()
 
     fun fetchData(year: Int, month: Int) = viewModelScope.launch {
-        _categoryUiState.value = CalendarUiState.Loading
         when (val result = accountRepository.getAllAccountOnDate(year, month)) {
-            is Result.Error -> _categoryUiState.value =
-                CalendarUiState.Error(R.string.error_history_get)
-            is Result.Success.Finish -> _categoryUiState.value =
-                CalendarUiState.SuccessFetch(result.data)
+            is Result.Error -> {}
+            is Result.Success.Finish -> _histories.value = result.data
         }
     }
-}
-
-sealed interface CalendarUiState {
-    object UnInitialized : CalendarUiState
-    object Loading : CalendarUiState
-
-    data class SuccessFetch(
-        val accounts: List<CalendarEntity>
-    ) : CalendarUiState
-
-    data class Error(
-        @StringRes
-        val errorMsg: Int
-    ) : CalendarUiState
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -118,7 +118,7 @@ fun TopRow(
         },
         right = {
             CustomText(
-                text = totalCount.toMoney(),
+                text = totalCount.toMoney(true),
                 style = MaterialTheme.typography.subtitle1,
                 color = ColorPalette.Red,
                 bold = true

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
@@ -1,17 +1,12 @@
 package com.seom.accountbook.ui.screen.graph
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.seom.accountbook.R
 import com.seom.accountbook.data.entity.Result
-import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.data.repository.AccountRepository
 import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
 import com.seom.accountbook.model.graph.OutComeByCategory
-import com.seom.accountbook.ui.screen.calendar.CalendarUiState
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/seom/accountbook/util/ext/IntExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/IntExtension.kt
@@ -4,6 +4,5 @@ import java.text.DecimalFormat
 
 val formatter = DecimalFormat("#,###")
 fun Int.toMoney(): String {
-    if (this == 0) return ""
     return formatter.format(this)
 }

--- a/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
@@ -1,4 +1,3 @@
 package com.seom.accountbook.util.ext
-import java.text.DecimalFormat
 
-fun Long.toMoney(): String = "${formatter.format(this)} 원"
+fun Long.toMoney(won: Boolean = false): String = "${formatter.format(this)} ${if (won) "원" else ""}"

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -43,10 +43,9 @@ fun AccountNavigationHost(
         }
         composable(route = Calendar.route) {
             CalendarScreen(
-                viewModel = viewModel(),
-                onPushNavigate = { route, argument ->
-                    navController.navigateSingleTop(route, argument)
-                }
+                mainViewModel = viewModel,
+                onDateChange = viewModel::setDate,
+                viewModel = viewModel()
             )
         }
         composable(route = Graph.route) {


### PR DESCRIPTION
### 📌 Summary
달력 화면의 Component 정리 및 세부 사항 구현하기

### 🍿 Main Changes 
- [x] 달력 화면의 Component 정리하기
- [x] 딜략 화면의 연도/월과 Graph 화면의 연도/월 연동하기
- [x] 달력 화면에서 가로 회전 시, 스크롤이 가능하도록 수정하기
- [x] [추가] graph 화면에서는 가로 회전 시, layout 변경하기

### 🔥 UseCase
1. 달력 화면의 연도/월과 graph 화면의 연도/월 연동
2. 달력 화면 회전 시, 스크롤 가능
3. graph 화면 회전 시, layout이 다름
<img width="827" alt="스크린샷 2022-08-03 오전 11 19 49" src="https://user-images.githubusercontent.com/22411296/182510135-907b130f-6813-4847-8626-7e8124e644da.png">

### 🛠 Related Issue
Closes #41 
